### PR TITLE
fix(staging): Enable database selector and mount custom addons as volumes

### DIFF
--- a/infra/stacks/odoo18-staging/config/odoo.conf
+++ b/infra/stacks/odoo18-staging/config/odoo.conf
@@ -15,7 +15,7 @@ db_maxconn = 64
 # Use .* to allow IP-based access to any database
 # For domain-based access, use: dbfilter = ^%d$
 dbfilter = .*
-list_db = False
+list_db = True
 
 # Admin password (temporary - must be rotated in Phase 1)
 admin_passwd = admin123

--- a/infra/stacks/odoo18-staging/docker-compose.yml
+++ b/infra/stacks/odoo18-staging/docker-compose.yml
@@ -57,6 +57,8 @@ services:
     volumes:
       - odoo18-staging-data:/var/lib/odoo
       - ./config/odoo.conf:/etc/odoo/odoo.conf:ro
+      - ../../../odoo_modules/seisei:/mnt/extra-addons/seisei:ro
+      - ../../../odoo_modules/community:/mnt/extra-addons/community:ro
     networks:
       - seisei-odoo-network
       - odoo18-staging-internal


### PR DESCRIPTION
## Summary

Fixes database access issues in staging environment by enabling database selector and properly mounting custom Odoo addons as volumes.

## Changes

### 1. Enable Database Selector (`odoo.conf`)
- **Changed**: `list_db = False` → `list_db = True`
- **Reason**: Allows IP-based access to database selector UI
- **Impact**: Users can now select databases when accessing via `http://54.178.13.108:8069`

### 2. Mount Custom Addons (`docker-compose.yml`)
- **Added**: Volume mounts for custom addons
  ```yaml
  - ../../../odoo_modules/seisei:/mnt/extra-addons/seisei:ro
  - ../../../odoo_modules/community:/mnt/extra-addons/community:ro
  ```
- **Reason**: Loads custom Seisei addons without requiring GHCR image pull
- **Impact**: Odoo now loads all custom modules from mounted directories

## Problem Solved

**Before**: "The database manager has been disabled by the administrator" error
**After**: ✅ Database selector works, custom addons loaded successfully

## Testing

- ✅ Container status: `odoo18-staging-web` (healthy)
- ✅ Database selector accessible: `http://54.178.13.108:8069/web/database/selector`
- ✅ Custom addons loaded: `/mnt/extra-addons/seisei`, `/mnt/extra-addons/community`
- ✅ RDS connection: SSL enabled to `seisei-odoo18-staging-rds.c1emceusojse.ap-northeast-1.rds.amazonaws.com`
- ✅ Workers: 4 HTTP + 2 Cron

## Migration Context

This is part of the migration from `server-apps` to `seisei-odoo-addons` as the single source of truth for deployment configuration.

## Future Work

- [ ] Configure GHCR authentication for production immutable image deployments
- [ ] Document GHCR token setup process for pulling custom images

## Deployment

Already deployed and verified on staging EC2 (54.178.13.108).
This PR captures the working configuration for version control.

🤖 Generated with Claude Code