### PR TITLE
fix(workflow): Use correct GitHub Secrets names for GHCR auth

### DIFF
--- a/.github/workflows/configure-ghcr-auth.yml
+++ b/.github/workflows/configure-ghcr-auth.yml
@@ -25,13 +25,13 @@ jobs:
       - name: Configure SSH key
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/id_rsa
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H 54.178.13.108 >> ~/.ssh/known_hosts
+          ssh-keyscan -H ${{ secrets.STAGING_SSH_HOST }} >> ~/.ssh/known_hosts
 
       - name: Configure Docker login on Staging
         run: |
-          ssh -i ~/.ssh/id_rsa ubuntu@54.178.13.108 << 'EOF'
+          ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@${{ secrets.STAGING_SSH_HOST }} << 'EOF'
             echo "Configuring Docker login for GHCR..."
             echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u cameltravel666-crypto --password-stdin
 
@@ -56,13 +56,13 @@ jobs:
       - name: Configure SSH key
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/id_rsa
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H 57.180.39.58 >> ~/.ssh/known_hosts
+          ssh-keyscan -H ${{ secrets.PRODUCTION_SSH_HOST }} >> ~/.ssh/known_hosts
 
       - name: Configure Docker login on Production
         run: |
-          ssh -i ~/.ssh/id_rsa ubuntu@57.180.39.58 << 'EOF'
+          ssh -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@${{ secrets.PRODUCTION_SSH_HOST }} << 'EOF'
             echo "Configuring Docker login for GHCR..."
             echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u cameltravel666-crypto --password-stdin
 


### PR DESCRIPTION
## Problem

The `configure-ghcr-auth.yml` workflow was referencing incorrect secret names:
- ❌ `EC2_SSH_KEY` (does not exist)
- ❌ Hardcoded IP addresses
- ❌ Hardcoded username `ubuntu`

## Solution

Updated workflow to use existing GitHub Secrets:
- ✅ `DEPLOY_SSH_KEY` - SSH private key (already exists)
- ✅ `STAGING_SSH_HOST` - Staging EC2 IP (54.178.13.108)
- ✅ `PRODUCTION_SSH_HOST` - Production EC2 IP (57.180.39.58)
- ✅ `SSH_USER` - SSH username (ubuntu)

## Changes

- Changed `secrets.EC2_SSH_KEY` → `secrets.DEPLOY_SSH_KEY`
- Changed hardcoded `54.178.13.108` → `secrets.STAGING_SSH_HOST`
- Changed hardcoded `57.180.39.58` → `secrets.PRODUCTION_SSH_HOST`
- Changed hardcoded `ubuntu` → `secrets.SSH_USER`

## Testing

After merge, we will run the workflow manually:
1. Go to Actions → "Configure GHCR Authentication"
2. Click "Run workflow"
3. Select target: "both" (staging + production)
4. Verify both jobs succeed
5. Verify Docker can pull GHCR images on both servers

## Related

- Part of Phase 1: GHCR Authentication Setup
- Follows PR #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)