### PR TITLE
feat(ocr): Use accounting mode by default for full line-item extraction

### DIFF
--- a/odoo_modules/seisei/odoo_ocr_final/__manifest__.py
+++ b/odoo_modules/seisei/odoo_ocr_final/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Financial OCR Integration',
-    'version': '18.0.13.2.0',
+    'version': '18.0.13.3.0',
     'category': 'Accounting',
     'summary': 'AI-powered OCR for Purchase Orders, Invoices, and Expenses',
     'description': '''


### PR DESCRIPTION
## Summary
Switch OCR processing from  mode to  mode by default to extract ALL line items from receipts/invoices.

## Problem
- 19-item 業務スーパー receipt: only extracted **8 items** ❌
- 41-item 業務スーパー receipt: only extracted **10 items** ❌
- Root cause: Using  → mapped to 
- Summary mode is designed for quick preview, not full extraction

## Solution
- **Parameter change**:  → 
- **Default change**:  → 
- Accounting mode extracts **complete line-by-line details**

## Changes
- Updated : Change default to 
- Updated : Change parameter name and default
- Updated : Send  to OCR service
- Updated : Version bump  → 

## Testing Plan
1. Deploy to **Staging** via CI/CD
2. Test with 41-item 業務スーパー receipt
3. Verify **ALL 41 items** are extracted
4. Verify tax rates are correct (8%/10%)
5. After validation, deploy to Production

## Breaking Change
⚠️ This changes the API parameter from  to . The OCR Central Service (v2.0.2) already supports both for backward compatibility.

## Related
- OCR Central Service: v2.0.2 (deployed on 13.159.193.191:8180)
- Staging Odoo: Connected and tested
- Production Odoo: Waiting for Staging validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)