### PR TITLE
fix(deploy): Pass GHCR_PAT correctly to remote server via SSH

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -174,16 +174,15 @@ jobs:
           echo "✅ Digest manifest uploaded to server: /tmp/image-digests.json"
 
       - name: Setup GHCR authentication on server
+        env:
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
         run: |
           echo "Setting up GHCR authentication on deployment server..."
+          # Pass GHCR_PAT through SSH to remote server
           ssh -i ~/.ssh/deploy_key \
             -o StrictHostKeyChecking=accept-new \
-            ${{ env.SSH_USER }}@${{ env.SSH_HOST }} bash -s <<'ENDSSH'
-          set -e
-          # Login to GHCR using secret PAT
-          echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
-          echo "✅ GHCR authentication configured"
-          ENDSSH
+            ${{ env.SSH_USER }}@${{ env.SSH_HOST }} \
+            "echo '$GHCR_PAT' | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin && echo '✅ GHCR authentication configured'"
 
       - name: Deploy to server
         id: deploy


### PR DESCRIPTION
## Problem
GHCR authentication step was failing because `GHCR_PAT` wasn't being passed correctly through SSH heredoc.

## Solution  
Changed from heredoc to direct SSH command with environment variable substitution.

## Changes
- Use `env:` block to capture `GHCR_PAT` secret
- Pass token through SSH using single command instead of heredoc
- This allows `$GHCR_PAT` to be substituted before SSH execution

🤖 Generated with Claude Code