### PR TITLE
fix: Enable immutable mode for Staging (match Production config)

### DIFF
--- a/infra/stacks/odoo18-staging/docker-compose.yml
+++ b/infra/stacks/odoo18-staging/docker-compose.yml
@@ -1,22 +1,23 @@
 # =============================================================================
-# Seisei Odoo 18 Staging Stack
+# Seisei Odoo 18 Staging Stack - Immutable Image Mode
 # =============================================================================
 # STAGING ENVIRONMENT - Uses SAME images as production, different configuration
 # - Images are pre-built by GitHub Actions and pushed to GHCR
 # - Staging tests the EXACT same image that will be deployed to production
 # - Server ONLY pulls images, NEVER builds locally
 # - Uses独立database (staging-db) to avoid affecting production data
+# - Immutable Mode: Uses code from image, NOT from server filesystem
 #
 # Deployment workflow:
 #   1. GitHub Actions builds and pushes image on main branch
-#   2. On staging server: update .env with new image tag
-#   3. Run: docker compose pull && docker compose up -d
-#   4. Run smoke tests to verify the deployment
-#   5. If tests pass, deploy same image to production
+#   2. Deploy script creates release snapshot in /srv/releases/stacks/
+#   3. Deploy script updates IMAGE_REF in .env with digest
+#   4. Deploy script runs: docker compose pull && docker compose up -d
+#   5. Run smoke tests to verify the deployment
+#   6. If tests pass, deploy same image to production
 #
 # Required environment variables in .env:
-#   GITHUB_REPO_OWNER    - GitHub organization/user (e.g., cameltravel666-crypto)
-#   ODOO18_IMAGE_TAG     - Image tag (can use 'latest' for staging, or specific SHA)
+#   IMAGE_REF            - Full image reference with digest (image@sha256:...)
 #   DB_PASSWORD          - PostgreSQL password (for staging-db)
 #   REDIS_PASSWORD       - Redis password
 #   OCR_SERVICE_URL      - Central OCR service URL
@@ -27,6 +28,7 @@
 #   - edge network must exist for Traefik routing
 #
 # ⚠️  IMPORTANT: Staging and Production must use the SAME image
+# ⚠️  Staging uses immutable image mode (no volume mounts for code)
 # ⚠️  Test thoroughly on staging before deploying to production
 # =============================================================================
 
@@ -55,10 +57,12 @@ services:
       - OCR_SERVICE_URL=${OCR_SERVICE_URL:-http://172.17.0.1:8180/api/v1}
       - OCR_SERVICE_KEY=${OCR_SERVICE_KEY}
     volumes:
+      # Data volume - persistent Odoo filestore
       - odoo18-staging-data:/var/lib/odoo
+      # Config file - environment-specific settings
       - ./config/odoo.conf:/etc/odoo/odoo.conf:ro
-      - ../../../odoo_modules/seisei:/mnt/extra-addons/seisei:ro
-      - ../../../odoo_modules/community:/mnt/extra-addons/community:ro
+      # NOTE: Code comes from IMAGE, not volume mounts (immutable mode)
+      # This ensures Staging tests the exact image that goes to Production
     networks:
       - seisei-odoo-network
       - odoo18-staging-internal


### PR DESCRIPTION
## Problem

Chart.js fix (PR #11) was deployed to Staging but **still shows error** because:

1. **Staging uses volume mounts** that override image code:
   ```yaml
   volumes:
     - ../../../odoo_modules/seisei:/mnt/extra-addons/seisei:ro  # ❌ Overrides image
   ```

2. **New module exists in image but not on server**:
   - Image `sha-1173f13` contains `seisei_chartjs_loader` module
   - Server filesystem `/opt/seisei-odoo-addons/` has old code without new module
   - Volume mount replaces image code with server code

3. **Staging ≠ Production configuration**:
   - Production uses immutable mode (code from image)
   - Staging uses volume mounts (code from server filesystem)
   - This violates the principle: "Staging tests the EXACT image that goes to Production"

## Root Cause

**Staging docker-compose.yml**:
```yaml
volumes:
  - odoo18-staging-data:/var/lib/odoo
  - ./config/odoo.conf:/etc/odoo/odoo.conf:ro
  - ../../../odoo_modules/seisei:/mnt/extra-addons/seisei:ro        # ❌ Problem
  - ../../../odoo_modules/community:/mnt/extra-addons/community:ro  # ❌ Problem
```

**Production docker-compose.yml** (correct):
```yaml
volumes:
  - odoo18-prod-data:/var/lib/odoo
  - ./config/odoo.conf:/etc/odoo/odoo.conf:ro
  # No code mounts - uses image ✅
```

## Solution

Remove source code volume mounts from Staging to match Production:

### Changes

1. **Updated Header Comments**:
   - Added "Immutable Image Mode" to title
   - Updated deployment workflow documentation
   - Clarified IMAGE_REF variable usage

2. **Removed Volume Mounts**:
   ```diff
   volumes:
     - odoo18-staging-data:/var/lib/odoo
     - ./config/odoo.conf:/etc/odoo/odoo.conf:ro
   - - ../../../odoo_modules/seisei:/mnt/extra-addons/seisei:ro
   - - ../../../odoo_modules/community:/mnt/extra-addons/community:ro
   + # NOTE: Code comes from IMAGE, not volume mounts (immutable mode)
   + # This ensures Staging tests the exact image that goes to Production
   ```

## Benefits

✅ **Fixes Chart.js Error**: `seisei_chartjs_loader` module now loads from image  
✅ **Configuration Parity**: Staging = Production deployment pattern  
✅ **True Immutable Infrastructure**: Code changes require new image build  
✅ **Prevents Configuration Drift**: Single source of truth (the image)  
✅ **Accurate Staging Tests**: Tests exact binary that deploys to Production  

## Testing Plan

1. ✅ Merge this PR
2. ⏳ Re-deploy `sha-1173f13` to Staging
3. ⏳ Verify Chart.js loads from image
4. ⏳ Confirm no "Chart is not defined" error
5. ⏳ Test accounting dashboard graphs render correctly

## Compliance

✅ Follows immutable infrastructure pattern  
✅ Staging-Production parity  
✅ No direct server modification  
✅ Industrial CI/CD standards  

## Impact

**Before**: Staging used server filesystem code (development mode)  
**After**: Staging uses image code (production mode)  

This is a **breaking change** if anyone was manually editing code on the server for Staging. All code changes now require:
1. Commit to Git
2. Build new image
3. Deploy via CI/CD

This is the **correct** industrial workflow.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)