### PR TITLE
fix: inject S3 credentials into staging deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -186,6 +186,12 @@ jobs:
 
       - name: Deploy to server
         id: deploy
+        env:
+          # S3 credentials for staging environment
+          STAGING_S3_ACCESS_KEY: ${{ secrets.STAGING_S3_ACCESS_KEY }}
+          STAGING_S3_SECRET_KEY: ${{ secrets.STAGING_S3_SECRET_KEY }}
+          STAGING_S3_BUCKET: ${{ secrets.STAGING_S3_BUCKET }}
+          STAGING_S3_REGION: ${{ secrets.STAGING_S3_REGION }}
         run: |
           STACK="${{ inputs.stack }}"
           ENV="${{ inputs.environment }}"
@@ -207,12 +213,21 @@ jobs:
             DEPLOY_CMD="$DEPLOY_CMD --break-glass --reason \"$BREAK_GLASS_REASON\""
           fi
 
+          # Prepare S3 environment variables for staging
+          S3_ENV_VARS=""
+          if [ "$ENV" = "staging" ]; then
+            S3_ENV_VARS="export DEPLOY_S3_ACCESS_KEY='$STAGING_S3_ACCESS_KEY'; export DEPLOY_S3_SECRET_KEY='$STAGING_S3_SECRET_KEY'; export DEPLOY_S3_BUCKET='$STAGING_S3_BUCKET'; export DEPLOY_S3_REGION='$STAGING_S3_REGION';"
+          fi
+
           # Execute deployment via SSH (NO git pull - immutable release pattern)
           ssh -i ~/.ssh/deploy_key \
             -o StrictHostKeyChecking=accept-new \
             -o ConnectTimeout=10 \
             ${{ env.SSH_USER }}@${{ env.SSH_HOST }} bash -s <<ENDSSH
           set -euo pipefail
+
+          # Export S3 credentials if provided (for staging)
+          $S3_ENV_VARS
 
           echo "=========================================="
           echo "Image as Source of Truth Deployment"


### PR DESCRIPTION
## Summary
- Fixes missing product images in Staging environment by properly injecting S3 credentials
- Ensures S3 credentials from GitHub Secrets are propagated to deployment .env file

## Problem
1. Product images showing placeholder icons in Staging
2. `.env` file created from `.env.example` has placeholder S3 credentials
3. Deploy script only updates `IMAGE_REF`, doesn't inject runtime secrets like S3 credentials

## Solution
**1. Modified `.github/workflows/deploy.yml`**:
- Added `STAGING_S3_ACCESS_KEY`, `STAGING_S3_SECRET_KEY`, `STAGING_S3_BUCKET`, `STAGING_S3_REGION` to deployment step environment
- Added logic to export these as `DEPLOY_S3_*` variables via SSH for staging deployments

**2. Modified `scripts/deploy.sh`**:
- Added S3 credential injection logic after `IMAGE_REF` update (line 358-376)
- Reads `DEPLOY_S3_ACCESS_KEY`, `DEPLOY_S3_SECRET_KEY`, `DEPLOY_S3_BUCKET`, `DEPLOY_S3_REGION` from environment
- Updates or appends `SEISEI_S3_ACCESS_KEY`, `SEISEI_S3_SECRET_KEY`, `SEISEI_S3_BUCKET`, `SEISEI_S3_REGION` in release `.env` file
- Falls back to `.env` defaults if deployment credentials not provided

## Flow
```
GitHub Secrets (STAGING_S3_*) 
  → GitHub Actions env 
  → SSH session (DEPLOY_S3_*) 
  → deploy.sh 
  → release .env (SEISEI_S3_*)
  → Docker container
  → Odoo seisei_s3_attachment module
```

## Test Plan
- [ ] Merge this PR
- [ ] Build new image with current main
- [ ] Deploy to Staging using GitHub Actions workflow
- [ ] Verify product images load from S3 bucket
- [ ] Check deployment logs for "✅ S3 credentials injected into .env"

## Related Issues
- Addresses missing product images reported in Staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)