### PR TITLE
fix: pass S3 env vars through sudo to preserve them

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -203,8 +203,15 @@ jobs:
 
           echo "::group::Deploying $STACK ($ENV) with $IMAGE_TAG"
 
-          # Build deploy command
-          DEPLOY_CMD="sudo ${{ env.REPO_PATH }}/scripts/deploy.sh \"$STACK\" \"$ENV\" \"$IMAGE_TAG\" \
+          # Prepare S3 environment variables for sudo (staging only)
+          # These will be passed directly through sudo to preserve them
+          SUDO_ENV_VARS=""
+          if [ "$ENV" = "staging" ]; then
+            SUDO_ENV_VARS="DEPLOY_S3_ACCESS_KEY='$STAGING_S3_ACCESS_KEY' DEPLOY_S3_SECRET_KEY='$STAGING_S3_SECRET_KEY' DEPLOY_S3_BUCKET='$STAGING_S3_BUCKET' DEPLOY_S3_REGION='$STAGING_S3_REGION'"
+          fi
+
+          # Build deploy command (pass env vars through sudo to avoid them being dropped)
+          DEPLOY_CMD="sudo $SUDO_ENV_VARS ${{ env.REPO_PATH }}/scripts/deploy.sh \"$STACK\" \"$ENV\" \"$IMAGE_TAG\" \
             --digest-file /tmp/image-digests.json \
             --actor \"$ACTOR\" \
             --run-id \"$RUN_ID\""
@@ -213,21 +220,12 @@ jobs:
             DEPLOY_CMD="$DEPLOY_CMD --break-glass --reason \"$BREAK_GLASS_REASON\""
           fi
 
-          # Prepare S3 environment variables for staging
-          S3_ENV_VARS=""
-          if [ "$ENV" = "staging" ]; then
-            S3_ENV_VARS="export DEPLOY_S3_ACCESS_KEY='$STAGING_S3_ACCESS_KEY'; export DEPLOY_S3_SECRET_KEY='$STAGING_S3_SECRET_KEY'; export DEPLOY_S3_BUCKET='$STAGING_S3_BUCKET'; export DEPLOY_S3_REGION='$STAGING_S3_REGION';"
-          fi
-
           # Execute deployment via SSH (NO git pull - immutable release pattern)
           ssh -i ~/.ssh/deploy_key \
             -o StrictHostKeyChecking=accept-new \
             -o ConnectTimeout=10 \
             ${{ env.SSH_USER }}@${{ env.SSH_HOST }} bash -s <<ENDSSH
           set -euo pipefail
-
-          # Export S3 credentials if provided (for staging)
-          $S3_ENV_VARS
 
           echo "=========================================="
           echo "Image as Source of Truth Deployment"


### PR DESCRIPTION
## Summary
- Fixes S3 credential injection by passing env vars explicitly through sudo
- Resolves issue where sudo was dropping DEPLOY_S3_* environment variables

## Problem Analysis
**Original Implementation (PR #13)**:
```bash
# Export env vars in bash session
export DEPLOY_S3_ACCESS_KEY='...'
export DEPLOY_S3_SECRET_KEY='...'

# Then call sudo (drops env vars!)
sudo deploy.sh ...
```

**Result**: deploy.sh never received the S3 credentials, product images still showing placeholders.

**Root Cause**: `sudo` drops environment variables by default for security.

## Solution
**New Implementation**:
```bash
# Pass env vars explicitly through sudo
SUDO_ENV_VARS="DEPLOY_S3_ACCESS_KEY='...' DEPLOY_S3_SECRET_KEY='...'"
sudo $SUDO_ENV_VARS deploy.sh ...
```

This ensures environment variables are explicitly passed to the sudo command and reach deploy.sh.

## Changes
- Modified `.github/workflows/deploy.yml` lines 206-230
- Moved S3 env var preparation before building DEPLOY_CMD
- Changed from export-based approach to sudo-inline approach
- Removed separate `S3_ENV_VARS` export step
- Environment variables now passed inline with sudo command

## Test Plan
- [ ] Merge this PR
- [ ] Trigger deployment to Staging with image sha-27bc07c
- [ ] Check deployment logs for "✅ S3 credentials injected into .env"
- [ ] Verify product images load from S3 bucket (not placeholders)
- [ ] Inspect release .env file to confirm S3 credentials present

## Related
- Fixes issue discovered after PR #13 deployment
- Completes S3 credentials injection feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)