### PR TITLE
feat: add workflow to update server scripts

### DIFF
--- a/.github/workflows/update-server-scripts.yml
+++ b/.github/workflows/update-server-scripts.yml
@@ -1,0 +1,98 @@
+name: Update Server Scripts
+
+on:
+  workflow_dispatch:
+    inputs:
+      server:
+        description: 'Target server (staging/production)'
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
+
+permissions:
+  contents: read
+
+env:
+  SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST || '54.65.127.141' }}
+  SSH_USER: ${{ secrets.DEPLOY_SSH_USER || 'ubuntu' }}
+  REPO_PATH: /opt/seisei-odoo-addons
+
+jobs:
+  update-scripts:
+    name: Update scripts on ${{ inputs.server }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.server }}
+
+    steps:
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ env.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Update server scripts
+        run: |
+          echo "::group::Updating scripts on ${{ inputs.server }} server"
+
+          ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=accept-new \
+            -o ConnectTimeout=10 \
+            ${{ env.SSH_USER }}@${{ env.SSH_HOST }} bash -s <<'ENDSSH'
+          set -euo pipefail
+
+          echo "=========================================="
+          echo "Updating Deployment Scripts"
+          echo "Server: ${{ inputs.server }}"
+          echo "Repo: ${{ env.REPO_PATH }}"
+          echo "=========================================="
+          echo ""
+
+          # Navigate to repository
+          cd ${{ env.REPO_PATH }}
+
+          # Show current branch and commit
+          echo "Current state:"
+          git branch --show-current
+          git log -1 --oneline
+          echo ""
+
+          # Pull latest changes from main
+          echo "Pulling latest changes..."
+          git fetch origin main
+          git reset --hard origin/main
+          echo ""
+
+          # Show updated commit
+          echo "Updated to:"
+          git log -1 --oneline
+          echo ""
+
+          # Verify script permissions
+          echo "Verifying script permissions..."
+          ls -la scripts/deploy.sh
+          chmod +x scripts/*.sh
+          echo ""
+
+          echo "✅ Server scripts updated successfully"
+          ENDSSH
+
+          echo "::endgroup::"
+
+      - name: Verify update
+        run: |
+          echo "### Server Scripts Updated" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Server:** \`${{ inputs.server }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Path:** \`${{ env.REPO_PATH }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status:** ✅ Scripts updated to latest main" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Next step:** Deploy your application to apply the updated scripts." >> $GITHUB_STEP_SUMMARY
+
+      - name: Cleanup SSH key
+        if: always()
+        run: |
+          rm -f ~/.ssh/deploy_key


### PR DESCRIPTION
## Summary
- Adds manual workflow to update deployment scripts on servers
- Solves the problem where server scripts become outdated

## Background

**Problem discovered:**
- PR #13, #14, #15 added S3 credential injection to `scripts/deploy.sh`
- Deploy workflow explicitly avoids `git pull` (immutable release pattern)
- Server scripts in `/opt/seisei-odoo-addons/` are never automatically updated
- Staging deployment failed because server has old `deploy.sh` without S3 injection logic

**Evidence:**
- Debug logs show S3 env vars correctly passed through sudo ✅
- But deploy script's S3 injection logging never appears ❌
- Product images still show placeholders ❌

## Solution

New workflow: `update-server-scripts.yml`

**Features:**
- Manual trigger via GitHub Actions
- Choose target: staging or production
- Executes on server:
  ```bash
  cd /opt/seisei-odoo-addons
  git fetch origin main
  git reset --hard origin/main
  chmod +x scripts/*.sh
  ```
- Verifies script permissions
- Provides summary of update

## Usage

**Step 1:** Run this workflow
```
Actions → Update Server Scripts → Run workflow → Select "staging"
```

**Step 2:** Deploy application
```
Actions → Deploy to Environment → Deploy odoo18-staging
```

## Test Plan
- [ ] Merge this PR
- [ ] Run update-server-scripts workflow for staging
- [ ] Verify server scripts updated via workflow logs
- [ ] Deploy sha-82ad939 to staging
- [ ] Check deploy logs for "✅ S3 credentials injected into .env"
- [ ] Verify product images load from S3 (not placeholders)

## Related
- Completes S3 fix from PR #13, #14, #15
- Addresses root cause of missing product images

🤖 Generated with [Claude Code](https://claude.com/claude-code)