### PR TITLE
feat: add S3 sync workflow (production → staging)

### DIFF
--- a/.github/workflows/sync-s3-prod-to-staging.yml
+++ b/.github/workflows/sync-s3-prod-to-staging.yml
@@ -1,0 +1,160 @@
+name: Sync S3 (Production → Staging)
+
+on:
+  workflow_dispatch:
+    inputs:
+      sync_mode:
+        description: 'Sync mode'
+        required: true
+        type: choice
+        options:
+          - dry-run
+          - full-sync
+        default: dry-run
+      delete_extra:
+        description: 'Delete files in staging that do not exist in production'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync-s3:
+    name: Sync S3 buckets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate inputs
+        run: |
+          echo "### S3 Sync Configuration" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Mode:** \`${{ inputs.sync_mode }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Delete extra files:** \`${{ inputs.delete_extra }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Actor:** \`${{ github.actor }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ inputs.sync_mode }}" = "dry-run" ]; then
+            echo "⚠️ **DRY RUN MODE** - No files will be copied" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "✅ **FULL SYNC MODE** - Files will be copied" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+      - name: Configure AWS credentials for source (production)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.PRODUCTION_S3_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.PRODUCTION_S3_SECRET_KEY }}
+          aws-region: ${{ secrets.PRODUCTION_S3_REGION || 'ap-northeast-1' }}
+
+      - name: Verify production bucket access (read-only)
+        env:
+          PROD_BUCKET: ${{ secrets.PRODUCTION_S3_BUCKET }}
+        run: |
+          echo "Verifying read access to production S3 bucket..."
+
+          # Test read-only access
+          if aws s3 ls s3://$PROD_BUCKET/ --max-items 1 > /dev/null 2>&1; then
+            echo "✅ Successfully verified read access to s3://$PROD_BUCKET"
+
+            # Get bucket size and object count
+            echo ""
+            echo "Production bucket statistics:"
+            aws s3 ls s3://$PROD_BUCKET/ --recursive --summarize | tail -2
+          else
+            echo "❌ Failed to access production bucket s3://$PROD_BUCKET"
+            exit 1
+          fi
+
+      - name: Sync to staging bucket
+        env:
+          PROD_BUCKET: ${{ secrets.PRODUCTION_S3_BUCKET }}
+          STAGING_BUCKET: ${{ secrets.STAGING_S3_BUCKET }}
+          STAGING_ACCESS_KEY: ${{ secrets.STAGING_S3_ACCESS_KEY }}
+          STAGING_SECRET_KEY: ${{ secrets.STAGING_S3_SECRET_KEY }}
+          STAGING_REGION: ${{ secrets.STAGING_S3_REGION || 'ap-northeast-1' }}
+          SYNC_MODE: ${{ inputs.sync_mode }}
+          DELETE_EXTRA: ${{ inputs.delete_extra }}
+        run: |
+          echo "=========================================="
+          echo "S3 Bucket Sync"
+          echo "Source:      s3://$PROD_BUCKET (production, read-only)"
+          echo "Destination: s3://$STAGING_BUCKET (staging, write)"
+          echo "Mode:        $SYNC_MODE"
+          echo "Delete:      $DELETE_EXTRA"
+          echo "=========================================="
+          echo ""
+
+          # Build sync command
+          SYNC_CMD="aws s3 sync s3://$PROD_BUCKET s3://$STAGING_BUCKET"
+
+          # Add dry-run flag if in dry-run mode
+          if [ "$SYNC_MODE" = "dry-run" ]; then
+            SYNC_CMD="$SYNC_CMD --dryrun"
+            echo "⚠️  DRY RUN MODE - No files will be copied"
+          fi
+
+          # Add delete flag if requested
+          if [ "$DELETE_EXTRA" = "true" ]; then
+            SYNC_CMD="$SYNC_CMD --delete"
+            echo "⚠️  DELETE MODE - Extra files in staging will be removed"
+          fi
+
+          echo ""
+          echo "Executing: $SYNC_CMD"
+          echo ""
+
+          # Configure credentials for destination bucket
+          export AWS_ACCESS_KEY_ID=$STAGING_ACCESS_KEY
+          export AWS_SECRET_ACCESS_KEY=$STAGING_SECRET_KEY
+          export AWS_DEFAULT_REGION=$STAGING_REGION
+
+          # Execute sync
+          $SYNC_CMD 2>&1 | tee /tmp/sync-output.txt
+
+          echo ""
+          echo "✅ Sync command completed"
+
+      - name: Generate summary
+        if: always()
+        env:
+          PROD_BUCKET: ${{ secrets.PRODUCTION_S3_BUCKET }}
+          STAGING_BUCKET: ${{ secrets.STAGING_S3_BUCKET }}
+          SYNC_MODE: ${{ inputs.sync_mode }}
+        run: |
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Sync Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ -f /tmp/sync-output.txt ]; then
+            # Count operations from sync output
+            UPLOADED=$(grep -c "upload:" /tmp/sync-output.txt || echo "0")
+            DOWNLOADED=$(grep -c "download:" /tmp/sync-output.txt || echo "0")
+            DELETED=$(grep -c "delete:" /tmp/sync-output.txt || echo "0")
+
+            echo "**Files processed:**" >> $GITHUB_STEP_SUMMARY
+            echo "- Uploaded: $UPLOADED" >> $GITHUB_STEP_SUMMARY
+            echo "- Downloaded: $DOWNLOADED" >> $GITHUB_STEP_SUMMARY
+            echo "- Deleted: $DELETED" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            if [ "$SYNC_MODE" = "dry-run" ]; then
+              echo "⚠️ This was a **dry run** - no actual changes were made" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "To perform the actual sync, run this workflow again with **full-sync** mode." >> $GITHUB_STEP_SUMMARY
+            else
+              echo "✅ Sync completed successfully" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Next step:** Refresh your Staging application to see the synced images." >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "⚠️ No sync output found" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Source:** \`s3://$PROD_BUCKET\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Destination:** \`s3://$STAGING_BUCKET\`" >> $GITHUB_STEP_SUMMARY

--- a/docs/S3_SYNC_SETUP.md
+++ b/docs/S3_SYNC_SETUP.md
@@ -1,0 +1,117 @@
+# S3 Sync Setup Guide
+
+## Overview
+
+This guide explains how to set up S3 synchronization from Production to Staging environments.
+
+## Required GitHub Secrets
+
+Add the following secrets to your GitHub repository:
+
+### Production S3 (Source - Read Only)
+
+| Secret Name | Description | Example Value |
+|------------|-------------|---------------|
+| `PRODUCTION_S3_BUCKET` | Production S3 bucket name | `seisei-odoo-production` |
+| `PRODUCTION_S3_REGION` | AWS region for production bucket | `ap-northeast-1` |
+| `PRODUCTION_S3_ACCESS_KEY` | AWS Access Key (read-only IAM user) | `AKIA...` |
+| `PRODUCTION_S3_SECRET_KEY` | AWS Secret Key (read-only IAM user) | `xxxxx...` |
+
+**⚠️ IMPORTANT:** Production credentials should be from a **read-only** IAM user with permissions:
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::seisei-odoo-production",
+        "arn:aws:s3:::seisei-odoo-production/*"
+      ]
+    }
+  ]
+}
+```
+
+### Staging S3 (Destination - Already Configured)
+
+These secrets should already exist from the S3 credentials fix:
+- `STAGING_S3_BUCKET` = `seisei-odoo-staging`
+- `STAGING_S3_REGION` = `ap-northeast-1`
+- `STAGING_S3_ACCESS_KEY`
+- `STAGING_S3_SECRET_KEY`
+
+## How to Add Secrets
+
+1. Go to: https://github.com/cameltravel666-crypto/seisei-odoo-addons/settings/secrets/actions
+2. Click "New repository secret"
+3. Add each secret listed above
+4. Click "Add secret"
+
+## How to Use the S3 Sync Workflow
+
+### Step 1: Dry Run (Preview)
+
+First, run a dry run to see what would be synced:
+
+1. Go to: **Actions** → **Sync S3 (Production → Staging)**
+2. Click **Run workflow**
+3. Select:
+   - **Sync mode:** `dry-run`
+   - **Delete extra files:** `false`
+4. Click **Run workflow**
+5. Review the output to see what files would be copied
+
+### Step 2: Full Sync
+
+After verifying the dry run output:
+
+1. Go to: **Actions** → **Sync S3 (Production → Staging)**
+2. Click **Run workflow**
+3. Select:
+   - **Sync mode:** `full-sync`
+   - **Delete extra files:** `false` (recommended)
+4. Click **Run workflow**
+5. Wait for completion
+
+### Step 3: Verify
+
+1. Refresh your Staging application: https://staging.odoo.seisei.tokyo
+2. Check if product images display correctly
+3. If images still don't appear, check browser cache or hard refresh (Ctrl+Shift+R)
+
+## Safety Features
+
+1. **Dry Run Mode**: Test before executing
+2. **Read-Only Source**: Production bucket is accessed read-only
+3. **Audit Trail**: All syncs are logged in GitHub Actions
+4. **Manual Trigger**: Sync only runs when explicitly triggered
+5. **Delete Protection**: Extra file deletion is opt-in
+
+## Troubleshooting
+
+### Issue: "Failed to access production bucket"
+
+**Solution:** Verify production S3 credentials are correct and have read permissions.
+
+### Issue: Images still not showing after sync
+
+**Possible causes:**
+1. Browser cache - try hard refresh (Ctrl+Shift+R)
+2. Odoo cache - restart Odoo containers
+3. S3 credentials not properly injected - check deployment logs
+
+### Issue: Sync is slow
+
+**Expected behavior:** First sync copies all files and may take time. Subsequent syncs only copy changed files.
+
+## Notes
+
+- **Data Safety**: Production data is never modified by this workflow
+- **Cost**: S3 data transfer between regions incurs AWS charges
+- **Frequency**: Run sync as needed, not on a schedule
+- **Selective Sync**: Currently syncs entire bucket. File filtering can be added if needed.


### PR DESCRIPTION
## Summary
- Adds secure S3 synchronization from Production to Staging
- Read-only access to production data
- Enables Staging to have same images as Production

## Background

**Current Architecture:**
- Production: RDS (production) + S3 (production bucket) → Images ✅
- Staging: RDS (staging/testodoo) + S3 (seisei-staging, empty) → Placeholders ❌

**Problem:**
- Staging S3 bucket is empty
- Product images in Staging show placeholders
- S3 configuration is correct, just no image data

## Solution

New workflow: `sync-s3-prod-to-staging.yml`

### Features

1. **Dry Run Mode** (default)
   - Preview what would be synced
   - No actual file transfer
   - Safe to test

2. **Full Sync Mode**
   - Copy all files from production to staging
   - Only copies changed/new files on subsequent runs
   - Efficient incremental sync

3. **Safety Controls**
   - Production bucket accessed **read-only**
   - Manual trigger only (no automatic schedule)
   - Optional delete protection
   - Complete audit trail in GitHub Actions

4. **AWS Credentials**
   - Uses GitHub Secrets for secure storage
   - Separate credentials for source (prod, read-only) and destination (staging, write)

## Setup Required

### Step 1: Add GitHub Secrets

Add 4 production S3 secrets (see `docs/S3_SYNC_SETUP.md`):

| Secret Name | Value | Notes |
|------------|-------|-------|
| `PRODUCTION_S3_BUCKET` | Production bucket name | e.g., `seisei-odoo-production` |
| `PRODUCTION_S3_REGION` | `ap-northeast-1` | AWS region |
| `PRODUCTION_S3_ACCESS_KEY` | Read-only IAM user key | **READ-ONLY** |
| `PRODUCTION_S3_SECRET_KEY` | Read-only IAM user secret | **READ-ONLY** |

**⚠️ CRITICAL:** Production credentials must be from a **read-only** IAM user!

### Step 2: Run Workflow

1. **Dry Run First** (recommended):
   ```
   Actions → Sync S3 → Run workflow
   - Mode: dry-run
   - Delete: false
   ```

2. **Review Output**: Check what files would be copied

3. **Full Sync**:
   ```
   Actions → Sync S3 → Run workflow
   - Mode: full-sync
   - Delete: false
   ```

4. **Verify**: Refresh Staging app, images should display

## Documentation

- Setup guide: `docs/S3_SYNC_SETUP.md`
- IAM policy for read-only access included
- Troubleshooting section

## Test Plan

- [ ] Merge this PR
- [ ] Add production S3 secrets to GitHub
- [ ] Run workflow in dry-run mode
- [ ] Review dry-run output
- [ ] Run workflow in full-sync mode
- [ ] Verify images display in Staging
- [ ] Confirm no changes to production data

## Safety Guarantees

✅ Production data is **never modified** (read-only access)
✅ Manual trigger only (no automatic schedule)
✅ Dry run preview before actual sync
✅ Complete audit trail in GitHub Actions
✅ Delete protection (opt-in only)

## Related

- Completes S3 configuration from PR #13, #14, #15, #16
- Enables data parity between Production and Staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)