### PR TITLE
fix(infra): Correct sudoers syntax for explicit denials

### DIFF
--- a/scripts/configure_deployer_permissions.sh
+++ b/scripts/configure_deployer_permissions.sh
@@ -154,12 +154,12 @@ deployer ALL=(root) NOPASSWD: /usr/bin/docker ps *
 # Explicitly DENIED commands (security hardening)
 # =============================================================================
 # Note: These are denied even if deployer somehow gets other sudo access
-deployer ALL=(root) !NOPASSWD: /usr/bin/docker exec *
-deployer ALL=(root) !NOPASSWD: /usr/bin/docker run *
-deployer ALL=(root) !NOPASSWD: /usr/bin/docker rm *
-deployer ALL=(root) !NOPASSWD: /bin/bash
-deployer ALL=(root) !NOPASSWD: /bin/sh
-deployer ALL=(root) !NOPASSWD: /usr/bin/sudo su
+deployer ALL=(root) NOPASSWD: !/usr/bin/docker exec *
+deployer ALL=(root) NOPASSWD: !/usr/bin/docker run *
+deployer ALL=(root) NOPASSWD: !/usr/bin/docker rm *
+deployer ALL=(root) NOPASSWD: !/bin/bash
+deployer ALL=(root) NOPASSWD: !/bin/sh
+deployer ALL=(root) NOPASSWD: !/usr/bin/sudo
 EOF
 
 log_info "Generated new sudoers configuration:"


### PR DESCRIPTION
## Issue

The deployer permissions configuration was failing with visudo syntax validation error.

## Root Cause

Invalid sudoers syntax for explicit denials:


## Fix

Use proper negation syntax with `!` before command path:


## Testing

This fix resolves the visudo syntax validation failure seen in workflow run:
https://github.com/cameltravel666-crypto/seisei-odoo-addons/actions/runs/21695301841

## Changes

- Fixed 6 explicit denial rules in `scripts/configure_deployer_permissions.sh`
- Moved `!` from before NOPASSWD to before command path
- Removed invalid `sudo su` entry (changed to just `sudo`)

Ready to merge and re-run configuration apply.