### PR TITLE
fix(deploy): Add sudo for docker login in GHCR authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -179,10 +179,11 @@ jobs:
         run: |
           echo "Setting up GHCR authentication on deployment server..."
           # Pass GHCR_PAT through SSH to remote server
+          # deployer user must use sudo to run docker login
           ssh -i ~/.ssh/deploy_key \
             -o StrictHostKeyChecking=accept-new \
             ${{ env.SSH_USER }}@${{ env.SSH_HOST }} \
-            "echo \"$GHCR_PAT\" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin && echo '✅ GHCR authentication configured'"
+            "echo \"$GHCR_PAT\" | sudo docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin && echo '✅ GHCR authentication configured'"
 
       - name: Deploy to server
         id: deploy


### PR DESCRIPTION
## Issue

Deployment failed during GHCR authentication because deployer user cannot run `docker login` without sudo.

## Fix

Added `sudo` before `docker login` command in deploy.yml line 186.

deployer user has sudo permission for:
```
deployer ALL=(root) NOPASSWD: /usr/bin/docker login ghcr.io *
```

## Testing

This fix enables deployer user to authenticate with GHCR during automated deployments.

Ready to merge and retry deployment.