### PR TITLE
fix: correct S3 bucket default to seisei-staging

### DIFF
--- a/infra/stacks/odoo18-staging/.env.example
+++ b/infra/stacks/odoo18-staging/.env.example
@@ -31,7 +31,7 @@ OCR_SERVICE_URL=http://13.159.193.191:8180/api/v1
 OCR_SERVICE_KEY=same-as-production-ocr-key
 
 # S3 Storage - use staging bucket or separate folder
-SEISEI_S3_BUCKET=seisei-odoo-staging
+SEISEI_S3_BUCKET=seisei-staging
 SEISEI_S3_REGION=ap-northeast-1
 SEISEI_S3_ACCESS_KEY=staging-s3-access-key
 SEISEI_S3_SECRET_KEY=staging-s3-secret-key

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -476,7 +476,7 @@ if [ -n "${DEPLOY_S3_ACCESS_KEY:-}" ] && [ -n "${DEPLOY_S3_SECRET_KEY:-}" ]; the
     log_info "Injecting S3 credentials from deployment environment ..."
 
     # Update or append S3 environment variables
-    for var in "SEISEI_S3_ACCESS_KEY:$DEPLOY_S3_ACCESS_KEY" "SEISEI_S3_SECRET_KEY:$DEPLOY_S3_SECRET_KEY" "SEISEI_S3_BUCKET:${DEPLOY_S3_BUCKET:-seisei-odoo-staging}" "SEISEI_S3_REGION:${DEPLOY_S3_REGION:-ap-northeast-1}"; do
+    for var in "SEISEI_S3_ACCESS_KEY:$DEPLOY_S3_ACCESS_KEY" "SEISEI_S3_SECRET_KEY:$DEPLOY_S3_SECRET_KEY" "SEISEI_S3_BUCKET:${DEPLOY_S3_BUCKET:-seisei-staging}" "SEISEI_S3_REGION:${DEPLOY_S3_REGION:-ap-northeast-1}"; do
         KEY="${var%%:*}"
         VALUE="${var#*:}"
         if grep -q "^${KEY}=" "$ENV_FILE"; then


### PR DESCRIPTION
## Summary
- Fix hardcoded S3 bucket fallback in `deploy.sh` from `seisei-odoo-staging` to `seisei-staging`
- Fix `.env.example` template for odoo18-staging stack
- Root cause of NoSuchBucket errors and white screen on Odoo staging after every deployment

## Test plan
- [ ] Deploy to staging and verify no S3 NoSuchBucket errors in logs
- [ ] Confirm Odoo login loads correctly (no white screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)