### PR TITLE
fix: enforce company filter in OCR tax matching

### DIFF
--- a/odoo_modules/seisei/custom_ocr_finance/models/account_move.py
+++ b/odoo_modules/seisei/custom_ocr_finance/models/account_move.py
@@ -426,13 +426,10 @@ class AccountMove(models.Model):
             ('amount_type', '=', 'percent'),
         ]
 
-        # Try company-specific tax first
+        # Search for tax matching the current company
         if self.company_id:
-            tax = Tax.search(domain + [('company_id', '=', self.company_id.id)], limit=1)
-            if tax:
-                return tax
+            domain.append(('company_id', '=', self.company_id.id))
 
-        # Fall back to any matching tax
         tax = Tax.search(domain, limit=1)
         return tax if tax else False
 


### PR DESCRIPTION
## Summary
- Remove cross-company tax search fallback in both `custom_ocr_finance` and `odoo_ocr_final`
- Root cause: when company-specific tax not found, fallback searched all companies and returned JP Company's 8% tax for Nagashiro bills
- Now tax search is always scoped to the bill's company

## Test plan
- [ ] Upload receipt on staging as Nagashiro company
- [ ] Apply OCR Lines - verify 8% tax assigned is Nagashiro's (tax_id=13), not JP Company's (tax_id=5)
- [ ] Confirm bill without "incompatible company" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)