### PR TITLE
fix: remove last ir.property call in duplicate _get_default_ocr_account

### DIFF
--- a/odoo_modules/seisei/odoo_ocr_final/models/account_move.py
+++ b/odoo_modules/seisei/odoo_ocr_final/models/account_move.py
@@ -633,10 +633,8 @@ class AccountMove(models.Model):
             if account:
                 return account
 
-        # Fallback to company default accounts
-        if is_purchase:
-            return self.env['ir.property']._get('property_account_expense_categ_id', 'product.category')
-        return self.env['ir.property']._get('property_account_income_categ_id', 'product.category')
+        # Fallback to company default accounts (Odoo 18: ir.property removed)
+        return self._get_default_expense_account() if is_purchase else self._get_default_income_account()
 
     def _find_or_create_product(self, name, price=0, is_sale=False):
         """Find product by name, create if not found.


### PR DESCRIPTION
## Summary
- Missed duplicate `_get_default_ocr_account` method at line 627 in `odoo_ocr_final` that still called `ir.property`
- This was the actual trigger for the "OCR processing error: 'ir.property'" on staging
- Replace with calls to already-fixed `_get_default_expense/income_account`

## Test plan
- [ ] Click "Apply OCR Lines" on staging bill - no ir.property error

🤖 Generated with [Claude Code](https://claude.com/claude-code)