### PR TITLE
fix: add git safe.directory in update-server-scripts workflow

### DIFF
--- a/.github/workflows/update-server-scripts.yml
+++ b/.github/workflows/update-server-scripts.yml
@@ -53,6 +53,7 @@ jobs:
 
           # Navigate to repository
           cd ${{ env.REPO_PATH }}
+          git config --global --add safe.directory ${{ env.REPO_PATH }}
 
           # Show current branch and commit
           echo "Current state:"


### PR DESCRIPTION
## Summary
- Production server fails with `dubious ownership in repository` error
- Add `git config --global --add safe.directory` before git operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)