### PR TITLE
fix: add sudo for git ops in update-server-scripts

### DIFF
--- a/.github/workflows/update-server-scripts.yml
+++ b/.github/workflows/update-server-scripts.yml
@@ -53,29 +53,29 @@ jobs:
 
           # Navigate to repository
           cd ${{ env.REPO_PATH }}
-          git config --global --add safe.directory ${{ env.REPO_PATH }}
+          sudo git config --global --add safe.directory ${{ env.REPO_PATH }}
 
           # Show current branch and commit
           echo "Current state:"
-          git branch --show-current
-          git log -1 --oneline
+          sudo git branch --show-current
+          sudo git log -1 --oneline
           echo ""
 
           # Pull latest changes from main
           echo "Pulling latest changes..."
-          git fetch origin main
-          git reset --hard origin/main
+          sudo git fetch origin main
+          sudo git reset --hard origin/main
           echo ""
 
           # Show updated commit
           echo "Updated to:"
-          git log -1 --oneline
+          sudo git log -1 --oneline
           echo ""
 
           # Verify script permissions
           echo "Verifying script permissions..."
           ls -la scripts/deploy.sh
-          chmod +x scripts/*.sh
+          sudo chmod +x scripts/*.sh
           echo ""
 
           echo "✅ Server scripts updated successfully"


### PR DESCRIPTION
## Summary
- Add `sudo` to all git write operations (`fetch`, `reset --hard`, `config`, `branch`, `log`) in the update-server-scripts workflow
- The deploy user (ubuntu) does not own `/opt/seisei-odoo-addons` on production, causing `Permission denied` on `.git/FETCH_HEAD`
- Also adds `sudo` to `chmod` for script permissions

## Context
Two consecutive workflow runs failed:
1. Run 1: `dubious ownership` — fixed by adding `safe.directory` (PR #35)
2. Run 2: `cannot open '.git/FETCH_HEAD': Permission denied` — **this PR**

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger "Update Server Scripts" workflow for production
- [ ] Verify workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)