### PR TITLE
fix: add --no-times to rsync for deployer user

### DIFF
--- a/.github/workflows/update-server-scripts.yml
+++ b/.github/workflows/update-server-scripts.yml
@@ -47,7 +47,7 @@ jobs:
           chmod +x scripts/*.sh
 
           # Sync repo directly (deploy user has group write via ubuntu group)
-          rsync -az --no-perms --no-owner --no-group \
+          rsync -rlz --no-perms --no-owner --no-group --no-times \
             --exclude='.git/' \
             --exclude='.github/' \
             --exclude='node_modules/' \


### PR DESCRIPTION
## Summary
- Add `--no-times` and switch from `-a` to `-rlz` in rsync command
- Deployer user has group write but can't set directory timestamps (requires ownership)
- Previous run transferred all files successfully but failed on timestamp metadata

## Test plan
- [ ] Merge and trigger workflow for production
- [ ] Verify all steps pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)