### PR TITLE
Add CRM API route to Odoo 19

### DIFF
--- a/infra/stacks/edge-traefik/dynamic/routes-prod.yml
+++ b/infra/stacks/edge-traefik/dynamic/routes-prod.yml
@@ -1,5 +1,18 @@
 http:
   routers:
+    # CRM API: www.seisei.tokyo/crm-api/* -> Odoo 19
+    crm-api-prod:
+      rule: "(Host(`seisei.tokyo`) || Host(`www.seisei.tokyo`)) && PathPrefix(`/crm-api`)"
+      service: odoo19-crm
+      priority: 200
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: cloudflare
+      middlewares:
+        - crm-strip-prefix
+        - secure-headers@file
+
     # Seisei Corporate Website
     seisei-www:
       rule: "Host(`seisei.tokyo`) || Host(`www.seisei.tokyo`)"
@@ -56,7 +69,19 @@ http:
       tls:
         certResolver: cloudflare
 
+  middlewares:
+    crm-strip-prefix:
+      stripPrefix:
+        prefixes:
+          - "/crm-api"
+
   services:
+    # Odoo 19 CRM API Service (external server)
+    odoo19-crm:
+      loadBalancer:
+        servers:
+          - url: "http://13.159.193.191:8069"
+
     # Seisei Corporate Website Service
     seisei-www:
       loadBalancer:

--- a/infra/stacks/edge-traefik/dynamic/routes-staging.yml
+++ b/infra/stacks/edge-traefik/dynamic/routes-staging.yml
@@ -1,5 +1,18 @@
 http:
   routers:
+    # CRM API: staging.www.seisei.tokyo/crm-api/* -> Odoo 19
+    crm-api-staging:
+      rule: "Host(`staging.www.seisei.tokyo`) && PathPrefix(`/crm-api`)"
+      service: odoo19-crm
+      priority: 200
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: cloudflare
+      middlewares:
+        - crm-strip-prefix
+        - secure-headers@file
+
     # Seisei Corporate Website Staging
     seisei-www-staging:
       rule: "Host(`staging.seisei.tokyo`) || Host(`staging.www.seisei.tokyo`)"
@@ -45,7 +58,19 @@ http:
       middlewares:
         - https-redirect@file
 
+  middlewares:
+    crm-strip-prefix:
+      stripPrefix:
+        prefixes:
+          - "/crm-api"
+
   services:
+    # Odoo 19 CRM API Service (external server)
+    odoo19-crm:
+      loadBalancer:
+        servers:
+          - url: "http://13.159.193.191:8069"
+
     # Seisei Corporate Website Service
     seisei-www-staging:
       loadBalancer:


### PR DESCRIPTION
## Summary
- Add `/crm-api/*` Traefik route pointing to external Odoo 19 server (`13.159.193.191:8069`)
- Configure for both staging (`staging.www.seisei.tokyo`) and production (`www.seisei.tokyo`)
- StripPrefix middleware removes `/crm-api` prefix before forwarding to Odoo 19
- Priority 200 ensures CRM API route takes precedence over catch-all website routes

## Test plan
- [x] Staging route verified: `staging.www.seisei.tokyo/crm-api/*` → Odoo 19 responds
- [x] Production route verified: `www.seisei.tokyo/crm-api/*` → Odoo 19 responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)