### PR TITLE
Add database filter header for CRM API route

### DIFF
--- a/infra/stacks/edge-traefik/dynamic/routes-prod.yml
+++ b/infra/stacks/edge-traefik/dynamic/routes-prod.yml
@@ -11,6 +11,7 @@ http:
         certResolver: cloudflare
       middlewares:
         - crm-strip-prefix
+        - crm-odoo19-dbfilter
         - secure-headers@file
 
     # Seisei Corporate Website
@@ -74,6 +75,11 @@ http:
       stripPrefix:
         prefixes:
           - "/crm-api"
+
+    crm-odoo19-dbfilter:
+      headers:
+        customRequestHeaders:
+          X-Odoo-dbfilter: "odoo19"
 
   services:
     # Odoo 19 CRM API Service (external server)

--- a/infra/stacks/edge-traefik/dynamic/routes-staging.yml
+++ b/infra/stacks/edge-traefik/dynamic/routes-staging.yml
@@ -11,6 +11,7 @@ http:
         certResolver: cloudflare
       middlewares:
         - crm-strip-prefix
+        - crm-odoo19-dbfilter
         - secure-headers@file
 
     # Seisei Corporate Website Staging
@@ -63,6 +64,11 @@ http:
       stripPrefix:
         prefixes:
           - "/crm-api"
+
+    crm-odoo19-dbfilter:
+      headers:
+        customRequestHeaders:
+          X-Odoo-dbfilter: "odoo19"
 
   services:
     # Odoo 19 CRM API Service (external server)


### PR DESCRIPTION
## Summary
- Add `X-Odoo-dbfilter: odoo19` header middleware for CRM API route
- Without this, Odoo 19 returns "No database is selected" (has 6 databases)
- Applied to both staging and production routes

## Test plan
- [ ] Staging: `staging.www.seisei.tokyo/crm-api/api/agent/apply` reaches correct Odoo 19 database

🤖 Generated with [Claude Code](https://claude.com/claude-code)