### PR TITLE
Fix CRM API: use X-Odoo-Database header

### DIFF
--- a/infra/stacks/edge-traefik/dynamic/routes-prod.yml
+++ b/infra/stacks/edge-traefik/dynamic/routes-prod.yml
@@ -79,7 +79,7 @@ http:
     crm-odoo19-dbfilter:
       headers:
         customRequestHeaders:
-          X-Odoo-dbfilter: "odoo19"
+          X-Odoo-Database: "odoo19"
 
   services:
     # Odoo 19 CRM API Service (external server)

--- a/infra/stacks/edge-traefik/dynamic/routes-staging.yml
+++ b/infra/stacks/edge-traefik/dynamic/routes-staging.yml
@@ -68,7 +68,7 @@ http:
     crm-odoo19-dbfilter:
       headers:
         customRequestHeaders:
-          X-Odoo-dbfilter: "odoo19"
+          X-Odoo-Database: "odoo19"
 
   services:
     # Odoo 19 CRM API Service (external server)


### PR DESCRIPTION
## Summary
- Fix database selection header: `X-Odoo-dbfilter` → `X-Odoo-Database`
- `X-Odoo-dbfilter` only sets a regex filter, doesn't select a database
- `X-Odoo-Database` explicitly selects the `odoo19` database

## Test plan
- [ ] Staging: `/crm-api/api/agent/apply` returns 500 (not 404 "No database selected")

🤖 Generated with [Claude Code](https://claude.com/claude-code)