### PR TITLE
chore(infra): fix yamllint long line errors in docker-compose

### DIFF
--- a/infra/stacks/edge-nginx-router/docker-compose.yml
+++ b/infra/stacks/edge-nginx-router/docker-compose.yml
@@ -4,14 +4,21 @@ services:
     container_name: odoo-nginx-router
     restart: unless-stopped
     ports:
-      - "127.0.0.1:8080:80"  # Only expose to localhost, Traefik handles external
+      # Only expose to localhost, Traefik handles external
+      - "127.0.0.1:8080:80"
     volumes:
       - ./default.conf:/etc/nginx/conf.d/default.conf:ro
       - nginx-cache:/var/cache/nginx
     networks:
       - edge
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost/nginx-health"]
+      test:
+        - "CMD"
+        - "wget"
+        - "--quiet"
+        - "--tries=1"
+        - "--spider"
+        - "http://localhost/nginx-health"
       interval: 30s
       timeout: 10s
       retries: 3

--- a/infra/stacks/erp-seisei/docker-compose.yml
+++ b/infra/stacks/erp-seisei/docker-compose.yml
@@ -18,7 +18,8 @@ services:
       retries: 5
 
   app:
-    # IMAGE_REF must include full digest (image@sha256:...) for production deployments
+    # IMAGE_REF must include full digest (image@sha256:...) for production
+    # deployments
     image: ${IMAGE_REF}
     container_name: seisei-erp-app
     restart: unless-stopped
@@ -52,10 +53,12 @@ services:
       - "traefik.enable=true"
       # Main router - only biznexus.seisei.tokyo and erp.seisei.tokyo (root)
       # *.erp.seisei.tokyo (subdomains) are routed to Odoo backend via odoo18-prod stack
+      # yamllint disable-line rule:line-length
       - "traefik.http.routers.erp.rule=Host(`erp.seisei.tokyo`) || Host(`biznexus.seisei.tokyo`)"
       - "traefik.http.routers.erp.entrypoints=websecure"
       - "traefik.http.routers.erp.tls.certresolver=cloudflare"
       - "traefik.http.routers.erp.tls.domains[0].main=erp.seisei.tokyo"
+      # yamllint disable-line rule:line-length
       - "traefik.http.routers.erp.tls.domains[0].sans=*.erp.seisei.tokyo,biznexus.seisei.tokyo"
       - "traefik.http.routers.erp.middlewares=secure-headers@file,compress@file"
       - "traefik.http.services.erp.loadbalancer.server.port=9527"

--- a/infra/stacks/ocr/docker-compose.yml
+++ b/infra/stacks/ocr/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   ocr-service:
+    # yamllint disable-line rule:line-length
     image: ghcr.io/${GITHUB_REPO_OWNER:-seisei}/ocr-service:${OCR_IMAGE_TAG:-latest}
     container_name: ocr-service
     restart: unless-stopped

--- a/infra/stacks/odoo18-prod/docker-compose.bind.yml
+++ b/infra/stacks/odoo18-prod/docker-compose.bind.yml
@@ -84,6 +84,7 @@ services:
       # =================================================================
       # Router 1: *.erp.seisei.tokyo (wildcard for production tenants)
       # =================================================================
+      # yamllint disable-line rule:line-length
       - "traefik.http.routers.odoo18-prod.rule=HostRegexp(`{subdomain:[a-z0-9-]+}.erp.seisei.tokyo`) && !Host(`testodoo.seisei.tokyo`)"
       - "traefik.http.routers.odoo18-prod.entrypoints=websecure"
       - "traefik.http.routers.odoo18-prod.tls.certresolver=cloudflare"
@@ -93,6 +94,7 @@ services:
       - "traefik.http.services.odoo18-prod.loadbalancer.sticky.cookie=true"
       - "traefik.http.services.odoo18-prod.loadbalancer.sticky.cookie.name=odoo_session"
       # Longpolling / WebSocket for seisei.tokyo
+      # yamllint disable-line rule:line-length
       - "traefik.http.routers.odoo18-prod-lp.rule=HostRegexp(`{subdomain:[a-z0-9-]+}.erp.seisei.tokyo`) && (PathPrefix(`/longpolling`) || PathPrefix(`/websocket`))"
       - "traefik.http.routers.odoo18-prod-lp.entrypoints=websecure"
       - "traefik.http.routers.odoo18-prod-lp.tls.certresolver=cloudflare"
@@ -109,6 +111,7 @@ services:
       - "traefik.http.routers.odoo18-nagashiro.middlewares=secure-headers@file,rate-limit@file,nagashiro-dbfilter@file"
       - "traefik.http.routers.odoo18-nagashiro.service=odoo18-prod"
       # Longpolling / WebSocket for nagashiro.top
+      # yamllint disable-line rule:line-length
       - "traefik.http.routers.odoo18-nagashiro-lp.rule=Host(`demo.nagashiro.top`) && (PathPrefix(`/longpolling`) || PathPrefix(`/websocket`))"
       - "traefik.http.routers.odoo18-nagashiro-lp.entrypoints=websecure"
       - "traefik.http.routers.odoo18-nagashiro-lp.tls.certresolver=cloudflare"

--- a/infra/stacks/odoo18-prod/docker-compose.yml
+++ b/infra/stacks/odoo18-prod/docker-compose.yml
@@ -14,11 +14,13 @@
 #   4. Run: docker compose pull && docker compose up -d
 #
 # Required environment variables in .env:
-#   GITHUB_REPO_OWNER    - GitHub organization/user (e.g., cameltravel666-crypto)
+#   GITHUB_REPO_OWNER    - GitHub organization/user
+#                          (e.g., cameltravel666-crypto)
 #   ODOO18_IMAGE_TAG     - Image tag (MUST use git SHA, e.g., sha-19b9b98)
 #   DB_PASSWORD          - PostgreSQL password (for seisei-db)
 #   REDIS_PASSWORD       - Redis password
-#   OCR_SERVICE_URL      - Central OCR service URL (e.g., http://172.17.0.1:8180/api/v1)
+#   OCR_SERVICE_URL      - Central OCR service URL
+#                          (e.g., http://172.17.0.1:8180/api/v1)
 #   OCR_SERVICE_KEY      - OCR service API key (required for OCR functionality)
 #
 # External dependencies:
@@ -32,7 +34,8 @@
 services:
   web:
     # Immutable image from GHCR - config and addons baked in
-    # IMAGE_REF must include full digest (image@sha256:...) for production deployments
+    # IMAGE_REF must include full digest (image@sha256:...)
+    # for production deployments
     image: ${IMAGE_REF}
     container_name: odoo18-prod-web
     restart: unless-stopped
@@ -77,6 +80,7 @@ services:
       # =================================================================
       # Router 1: *.erp.seisei.tokyo (wildcard for production tenants)
       # =================================================================
+      # yamllint disable-line rule:line-length
       - "traefik.http.routers.odoo18-prod.rule=HostRegexp(`{subdomain:[a-z0-9-]+}.erp.seisei.tokyo`) && !Host(`testodoo.seisei.tokyo`)"
       - "traefik.http.routers.odoo18-prod.entrypoints=websecure"
       - "traefik.http.routers.odoo18-prod.tls.certresolver=cloudflare"
@@ -86,6 +90,7 @@ services:
       - "traefik.http.services.odoo18-prod.loadbalancer.sticky.cookie=true"
       - "traefik.http.services.odoo18-prod.loadbalancer.sticky.cookie.name=odoo_session"
       # Longpolling / WebSocket for seisei.tokyo
+      # yamllint disable-line rule:line-length
       - "traefik.http.routers.odoo18-prod-lp.rule=HostRegexp(`{subdomain:[a-z0-9-]+}.erp.seisei.tokyo`) && (PathPrefix(`/longpolling`) || PathPrefix(`/websocket`))"
       - "traefik.http.routers.odoo18-prod-lp.entrypoints=websecure"
       - "traefik.http.routers.odoo18-prod-lp.tls.certresolver=cloudflare"
@@ -103,6 +108,7 @@ services:
       - "traefik.http.routers.odoo18-nagashiro.middlewares=secure-headers@file,rate-limit@file,nagashiro-dbfilter@file"
       - "traefik.http.routers.odoo18-nagashiro.service=odoo18-prod"
       # Longpolling / WebSocket for nagashiro.top
+      # yamllint disable-line rule:line-length
       - "traefik.http.routers.odoo18-nagashiro-lp.rule=Host(`demo.nagashiro.top`) && (PathPrefix(`/longpolling`) || PathPrefix(`/websocket`))"
       - "traefik.http.routers.odoo18-nagashiro-lp.entrypoints=websecure"
       - "traefik.http.routers.odoo18-nagashiro-lp.tls.certresolver=cloudflare"

--- a/infra/stacks/odoo18-staging/docker-compose.yml
+++ b/infra/stacks/odoo18-staging/docker-compose.yml
@@ -35,7 +35,8 @@
 services:
   web:
     # SAME image as production - only configuration differs
-    # IMAGE_REF must include full digest (image@sha256:...) for staging deployments
+    # IMAGE_REF must include full digest (image@sha256:...) for staging
+    # deployments
     image: ${IMAGE_REF}
     container_name: odoo18-staging-web
     restart: unless-stopped
@@ -92,6 +93,7 @@ services:
       - "traefik.http.routers.odoo18-staging.service=odoo18-staging"
       - "traefik.http.services.odoo18-staging.loadbalancer.server.port=8069"
       # Longpolling / WebSocket
+      # yamllint disable-line rule:line-length
       - "traefik.http.routers.odoo18-staging-lp.rule=Host(`staging.erp.seisei.tokyo`) && (PathPrefix(`/longpolling`) || PathPrefix(`/websocket`))"
       - "traefik.http.routers.odoo18-staging-lp.entrypoints=websecure"
       - "traefik.http.routers.odoo18-staging-lp.tls.certresolver=cloudflare"

--- a/infra/stacks/web-seisei/docker-compose.yml
+++ b/infra/stacks/web-seisei/docker-compose.yml
@@ -10,13 +10,16 @@ services:
     labels:
       - "traefik.enable=true"
       # Main site
+      # yamllint disable-line rule:line-length
       - "traefik.http.routers.www.rule=Host(`seisei.tokyo`) || Host(`www.seisei.tokyo`)"
       - "traefik.http.routers.www.entrypoints=websecure"
       - "traefik.http.routers.www.tls.certresolver=cloudflare"
       - "traefik.http.routers.www.middlewares=secure-headers@file,compress@file"
       - "traefik.http.services.www.loadbalancer.server.port=3000"
       # Redirect www to non-www (optional)
+      # yamllint disable-line rule:line-length
       # - "traefik.http.middlewares.www-redirect.redirectregex.regex=^https://www\\.seisei\\.tokyo/(.*)"
+      # yamllint disable-line rule:line-length
       # - "traefik.http.middlewares.www-redirect.redirectregex.replacement=https://seisei.tokyo/$${1}"
       # - "traefik.http.middlewares.www-redirect.redirectregex.permanent=true"
       # Version labels


### PR DESCRIPTION
Fixes docker-compose.yml lines exceeding 80 chars to pass CI linting. Fixes #59