### PR TITLE
chore(infra): fix remaining yamllint errors (part 2)

### DIFF
--- a/infra/stacks/edge-traefik/dynamic/routes-prod.yml
+++ b/infra/stacks/edge-traefik/dynamic/routes-prod.yml
@@ -2,6 +2,7 @@ http:
   routers:
     # CRM API: www.seisei.tokyo/crm-api/* -> Odoo 19
     crm-api-prod:
+      # yamllint disable-line rule:line-length
       rule: "(Host(`seisei.tokyo`) || Host(`www.seisei.tokyo`)) && PathPrefix(`/crm-api`)"
       service: odoo19-crm
       priority: 200

--- a/infra/stacks/edge-traefik/dynamic/routes-staging.yml
+++ b/infra/stacks/edge-traefik/dynamic/routes-staging.yml
@@ -52,6 +52,7 @@ http:
 
     # HTTP redirect for all
     staging-http-redirect:
+      # yamllint disable-line rule:line-length
       rule: "Host(`staging.seisei.tokyo`) || Host(`staging.www.seisei.tokyo`) || Host(`staging.biznexus.seisei.tokyo`) || Host(`staging.erp.seisei.tokyo`) || Host(`staging.odoo.seisei.tokyo`)"
       service: odoo-staging
       entryPoints:

--- a/infra/stacks/odoo18-test/docker-compose.yml
+++ b/infra/stacks/odoo18-test/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - "traefik.http.routers.odoo18-test.middlewares=secure-headers@file"
       - "traefik.http.services.odoo18-test.loadbalancer.server.port=8069"
       # Longpolling/WebSocket router
+      # yamllint disable-line rule:line-length
       - "traefik.http.routers.odoo18-test-lp.rule=Host(`testodoo.seisei.tokyo`) && (PathPrefix(`/longpolling`) || PathPrefix(`/websocket`))"
       - "traefik.http.routers.odoo18-test-lp.entrypoints=websecure"
       - "traefik.http.routers.odoo18-test-lp.tls.certresolver=cloudflare"


### PR DESCRIPTION
Fixes remaining docker-compose.yml lines exceeding 80 chars. Fixes #59