### PR TITLE
fix(ci): move SSH_HOST to job-level env for environment secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,8 +40,6 @@ permissions:
   contents: read
 
 env:
-  SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST || '54.65.127.141' }}
-  SSH_USER: ${{ secrets.DEPLOY_SSH_USER || 'ubuntu' }}
   REPO_PATH: /opt/seisei-odoo-addons
 
 jobs:
@@ -50,6 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     # Use GitHub Environments for protection rules (approval, secrets, etc.)
     environment: ${{ inputs.environment }}
+    env:
+      SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST || '54.65.127.141' }}
+      SSH_USER: ${{ secrets.DEPLOY_SSH_USER || 'ubuntu' }}
 
     steps:
       - name: Validate inputs

--- a/.github/workflows/update-server-scripts.yml
+++ b/.github/workflows/update-server-scripts.yml
@@ -16,8 +16,6 @@ permissions:
   contents: read
 
 env:
-  SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST || '54.65.127.141' }}
-  SSH_USER: ${{ secrets.DEPLOY_SSH_USER || 'ubuntu' }}
   REPO_PATH: /opt/seisei-odoo-addons
 
 jobs:
@@ -25,6 +23,9 @@ jobs:
     name: Update scripts on ${{ inputs.server }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.server }}
+    env:
+      SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST || '54.65.127.141' }}
+      SSH_USER: ${{ secrets.DEPLOY_SSH_USER || 'ubuntu' }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Closes #75

## Summary
- Move `SSH_HOST` and `SSH_USER` from workflow-level `env` to job-level `env`
- Workflow-level `env` cannot read environment-specific secrets, so staging deployments were always targeting the production server
- Affects both `deploy.yml` and `update-server-scripts.yml`

## Test plan
- [ ] Run "Update Server Scripts" workflow with `staging` target
- [ ] Verify code is synced to staging server (not production)
- [ ] Verify QR ordering variant display fix is live on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)