### PR TITLE
feat(ocr): optimize PROMPT_FULL v2.0 — JGAAP compliance & higher extraction rate

### DIFF
--- a/odoo_modules/seisei/odoo_ocr_final/__manifest__.py
+++ b/odoo_modules/seisei/odoo_ocr_final/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Financial OCR Integration',
-    'version': '18.0.13.4.0',
+    'version': '18.0.13.5.0',
     'category': 'Accounting',
     'summary': 'AI-powered OCR for Purchase Orders, Invoices, and Expenses',
     'description': '''


### PR DESCRIPTION
Closes #80

## Summary
- Rewrite `PROMPT_FULL` v2.0 to fix 43% empty `line_items` failure rate from 80-receipt batch test
- Add explicit handling for 13+ Japanese document types (taxi, parking, rail, restaurant, postal, hotel, etc.) with proper 勘定科目 mappings
- Add defensive fallback in `llm_ocr.py`: create summary line from totals when Gemini returns empty lines
- Enable JSON mode + temperature=0 for deterministic accounting accuracy

## Changes
| File | Change |
|------|--------|
| `services/ocr_service/main.py` | PROMPT_FULL rewrite + JSON mode + v1.4.0 |
| `odoo_modules/.../llm_ocr.py` | Fallback summary line when lines empty |
| `odoo_modules/.../__manifest__.py` | 18.0.13.4.0 → 18.0.13.5.0 |

## Deployment Plan (方案A — 渐进式)
1. **Merge** → `ocr-service.yml` auto-builds & deploys new prompt to OCR central service (13.159.193.191)
2. **Manual** `update-server-scripts` → staging → restart staging Odoo → verify
3. **Batch test** on staging with receipts
4. **Manual** `update-server-scripts` → production → restart production Odoo

⚠️ OCR central service is shared by staging + production. Prompt change affects both immediately on merge.

## Test plan
- [ ] Verify `ocr-service.yml` builds and deploys successfully
- [ ] rsync to staging, restart Odoo container
- [ ] Upload taxi/parking/rail receipts → verify non-empty lines with 旅費交通費
- [ ] Upload supermarket receipts → verify line items with correct tax rates
- [ ] Upload restaurant receipts → verify 福利厚生費/会議費/交際費 mapping
- [ ] Verify fallback: confirm no empty line_items in any case
- [ ] rsync to production after staging verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)