### PR TITLE
fix(bank-statement-ocr): correct menu XML ID for Odoo 18 CE

### DIFF
--- a/odoo_modules/seisei/seisei_bank_statement_ocr/views/bank_statement_ocr_views.xml
+++ b/odoo_modules/seisei/seisei_bank_statement_ocr/views/bank_statement_ocr_views.xml
@@ -150,7 +150,7 @@
     <!-- ========== Menu (under Accounting) ========== -->
     <menuitem id="menu_bank_statement_ocr"
               name="OCR対账単"
-              parent="account.menu_finance_bank_and_cash"
+              parent="account.menu_finance_entries"
               action="action_bank_statement_ocr"
               sequence="20"/>
 </odoo>


### PR DESCRIPTION
Fixes #88

## Summary
- `account.menu_finance_bank_and_cash` does not exist in Odoo 18 CE, causing `ValueError` on module installation
- Changed menu parent to `account.menu_finance_entries` (verified working across all project modules)

## Test plan
- [ ] Merge → build_ghcr → deploy → update-server-scripts
- [ ] Install `seisei_bank_statement_ocr` module in staging without error
- [ ] Verify "OCR対账単" menu appears under 会計 > 仕訳帳

🤖 Generated with [Claude Code](https://claude.com/claude-code)