### PR TITLE
feat(bank-statement-ocr): OCR service bank_statement + simplified wizard + trilingual

### DIFF
--- a/odoo_modules/seisei/seisei_bank_statement_ocr/__manifest__.py
+++ b/odoo_modules/seisei/seisei_bank_statement_ocr/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': '銀行取引明細OCR / Bank Statement OCR',
-    'version': '18.0.1.0.0',
+    'version': '18.0.1.1.0',
     'category': 'Accounting',
     'summary': 'OCR import for scanned bank statements (PDF/Image)',
     'description': """

--- a/odoo_modules/seisei/seisei_bank_statement_ocr/models/bank_statement_ocr_line.py
+++ b/odoo_modules/seisei/seisei_bank_statement_ocr/models/bank_statement_ocr_line.py
@@ -7,21 +7,22 @@ class SeiseiBankStatementOcrLine(models.Model):
     _order = 'date, sequence'
 
     ocr_id = fields.Many2one('seisei.bank.statement.ocr', required=True, ondelete='cascade')
-    sequence = fields.Integer('順番', default=10)
-    date = fields.Date('日付', required=True)
-    description = fields.Char('摘要', required=True)
-    withdrawal = fields.Float('出金', digits=(16, 0))
-    deposit = fields.Float('入金', digits=(16, 0))
-    balance = fields.Float('残高', digits=(16, 0))
-    reference = fields.Char('整理番号')
-    partner_id = fields.Many2one('res.partner', 'パートナー')
-    partner_name = fields.Char('取引先名（OCR）')
+    sequence = fields.Integer('順番 / 序号 / Seq', default=10)
+    date = fields.Date('日付 / 日期 / Date', required=True)
+    description = fields.Char('摘要 / 摘要 / Description', required=True)
+    withdrawal = fields.Float('出金 / 支出 / Withdrawal', digits=(16, 0))
+    deposit = fields.Float('入金 / 收入 / Deposit', digits=(16, 0))
+    balance = fields.Float('残高 / 余额 / Balance', digits=(16, 0))
+    reference = fields.Char('整理番号 / 编号 / Reference')
+    partner_id = fields.Many2one('res.partner', 'パートナー / 合作伙伴 / Partner')
+    partner_name = fields.Char('取引先名 / 交易方 / Counterparty (OCR)')
 
     amount = fields.Float(
-        '金額', compute='_compute_amount', store=True, digits=(16, 0),
+        '金額 / 金额 / Amount', compute='_compute_amount', store=True, digits=(16, 0),
     )
     balance_warning = fields.Boolean(
-        '残高不整合', compute='_compute_balance_warning', store=True,
+        '残高不整合 / 余额异常 / Balance Warning',
+        compute='_compute_balance_warning', store=True,
     )
 
     @api.depends('deposit', 'withdrawal')

--- a/odoo_modules/seisei/seisei_bank_statement_ocr/security/ir.model.access.csv
+++ b/odoo_modules/seisei/seisei_bank_statement_ocr/security/ir.model.access.csv
@@ -4,4 +4,3 @@ access_bank_statement_ocr_manager,seisei.bank.statement.ocr.manager,model_seisei
 access_bank_statement_ocr_line_user,seisei.bank.statement.ocr.line.user,model_seisei_bank_statement_ocr_line,account.group_account_invoice,1,1,1,0
 access_bank_statement_ocr_line_manager,seisei.bank.statement.ocr.line.manager,model_seisei_bank_statement_ocr_line,account.group_account_manager,1,1,1,1
 access_bank_statement_ocr_upload_user,seisei.bank.statement.ocr.upload.user,model_seisei_bank_statement_ocr_upload,account.group_account_invoice,1,1,1,0
-access_bank_statement_ocr_upload_line_user,seisei.bank.statement.ocr.upload.line.user,model_seisei_bank_statement_ocr_upload_line,account.group_account_invoice,1,1,1,0

--- a/odoo_modules/seisei/seisei_bank_statement_ocr/views/account_journal_views.xml
+++ b/odoo_modules/seisei/seisei_bank_statement_ocr/views/account_journal_views.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
-    <!-- Add "上传" (OCR Upload) button to bank journal card on accounting dashboard -->
+    <!-- Add OCR Upload button to bank journal card on accounting dashboard -->
     <record id="account_journal_dashboard_kanban_view_ocr" model="ir.ui.view">
         <field name="name">account.journal.kanban.ocr.bank.statement</field>
         <field name="model">account.journal</field>
@@ -10,7 +10,7 @@
                 <a name="action_ocr_bank_statement_upload" type="object"
                    class="oe_inline" style="margin-right: 8px;"
                    groups="account.group_account_invoice">
-                    上传
+                    OCR上传
                 </a>
             </xpath>
         </field>

--- a/odoo_modules/seisei/seisei_bank_statement_ocr/views/bank_statement_ocr_views.xml
+++ b/odoo_modules/seisei/seisei_bank_statement_ocr/views/bank_statement_ocr_views.xml
@@ -8,16 +8,16 @@
             <form>
                 <header>
                     <button name="action_process_ocr" type="object"
-                            string="OCR開始" class="btn-primary"
+                            string="OCR開始 / 开始OCR / Start OCR" class="btn-primary"
                             invisible="state != 'draft'"/>
                     <button name="action_confirm_import" type="object"
-                            string="対账単として取り込む" class="btn-primary"
+                            string="対账単取込 / 导入对账单 / Import Statement" class="btn-primary"
                             invisible="state != 'review'"/>
                     <button name="action_process_ocr" type="object"
-                            string="OCR再実行" class="btn-secondary"
+                            string="OCR再実行 / 重新OCR / Retry OCR" class="btn-secondary"
                             invisible="state not in ('review', 'failed')"/>
                     <button name="action_reset_to_draft" type="object"
-                            string="リセット" class="btn-secondary"
+                            string="リセット / 重置 / Reset" class="btn-secondary"
                             invisible="state in ('draft', 'done')"/>
                     <field name="state" widget="statusbar"
                            statusbar_visible="draft,processing,review,done"/>
@@ -26,19 +26,18 @@
                     <!-- Balance warning banner -->
                     <div class="alert alert-warning" role="alert"
                          invisible="balance_check_ok or state not in ('review',)">
-                        <strong>残高不整合:</strong>
+                        <strong>残高不整合 / 余额不平衡 / Balance Mismatch:</strong>
                         期首残高 + 入金合計 - 出金合計 と 期末残高 に
                         <field name="balance_diff" class="oe_inline"/> 円の差があります。
-                        取引明細を確認してください。
                     </div>
                     <!-- Error message -->
                     <div class="alert alert-danger" role="alert"
                          invisible="state != 'failed'">
-                        <strong>OCRエラー:</strong>
+                        <strong>OCRエラー / OCR错误 / OCR Error:</strong>
                         <field name="ocr_error_message"/>
                     </div>
                     <group>
-                        <group string="銀行情報">
+                        <group string="銀行情報 / 银行信息 / Bank Info">
                             <field name="journal_id"
                                    readonly="state != 'draft'"/>
                             <field name="bank_name"/>
@@ -46,7 +45,7 @@
                             <field name="account_number"/>
                             <field name="account_holder"/>
                         </group>
-                        <group string="対账単情報">
+                        <group string="対账単情報 / 对账单信息 / Statement Info">
                             <field name="statement_period"/>
                             <field name="statement_date"/>
                             <field name="balance_start"/>
@@ -55,11 +54,12 @@
                             <field name="ocr_pages" readonly="1"/>
                         </group>
                     </group>
-                    <group string="スキャンファイル" invisible="state not in ('draft', 'failed')">
+                    <group string="スキャンファイル / 扫描文件 / Scan Files"
+                           invisible="state not in ('draft', 'failed')">
                         <field name="attachment_ids" widget="many2many_binary"/>
                     </group>
                     <notebook>
-                        <page string="取引明細" name="lines">
+                        <page string="取引明細 / 交易明细 / Transactions" name="lines">
                             <field name="line_ids" nolabel="1">
                                 <list editable="bottom">
                                     <field name="sequence" widget="handle"/>
@@ -77,7 +77,7 @@
                                 </list>
                             </field>
                         </page>
-                        <page string="OCR生データ" name="raw"
+                        <page string="OCR生データ / OCR原始数据 / OCR Raw Data" name="raw"
                               invisible="not ocr_raw_data">
                             <field name="ocr_raw_data" readonly="1"/>
                         </page>
@@ -124,15 +124,17 @@
                 <field name="name"/>
                 <field name="bank_name"/>
                 <field name="journal_id"/>
-                <filter name="filter_review" string="確認待ち"
+                <filter name="filter_review" string="確認待ち / 待确认 / Pending Review"
                         domain="[('state', '=', 'review')]"/>
-                <filter name="filter_done" string="インポート済み"
+                <filter name="filter_done" string="インポート済 / 已导入 / Imported"
                         domain="[('state', '=', 'done')]"/>
-                <filter name="filter_failed" string="エラー"
+                <filter name="filter_failed" string="エラー / 错误 / Error"
                         domain="[('state', '=', 'failed')]"/>
-                <group expand="0" string="グループ">
-                    <filter name="group_state" string="状態" context="{'group_by': 'state'}"/>
-                    <filter name="group_journal" string="銀行口座" context="{'group_by': 'journal_id'}"/>
+                <group expand="0" string="グループ / 分组 / Group By">
+                    <filter name="group_state" string="状態 / 状态 / State"
+                            context="{'group_by': 'state'}"/>
+                    <filter name="group_journal" string="銀行口座 / 银行账户 / Bank"
+                            context="{'group_by': 'journal_id'}"/>
                 </group>
             </search>
         </field>
@@ -140,16 +142,16 @@
 
     <!-- ========== Action ========== -->
     <record id="action_bank_statement_ocr" model="ir.actions.act_window">
-        <field name="name">OCR対账単</field>
+        <field name="name">OCR対账単 / OCR对账单 / OCR Statements</field>
         <field name="res_model">seisei.bank.statement.ocr</field>
         <field name="view_mode">list,form</field>
         <field name="search_view_id" ref="view_bank_statement_ocr_search"/>
         <field name="context">{'search_default_filter_review': 1}</field>
     </record>
 
-    <!-- ========== Menu (under Accounting) ========== -->
+    <!-- ========== Menu (under Accounting > Journal Entries) ========== -->
     <menuitem id="menu_bank_statement_ocr"
-              name="OCR対账単"
+              name="OCR対账単 / OCR对账单 / OCR Statements"
               parent="account.menu_finance_entries"
               action="action_bank_statement_ocr"
               sequence="20"/>

--- a/odoo_modules/seisei/seisei_bank_statement_ocr/views/wizard_views.xml
+++ b/odoo_modules/seisei/seisei_bank_statement_ocr/views/wizard_views.xml
@@ -5,38 +5,20 @@
         <field name="name">seisei.bank.statement.ocr.upload.form</field>
         <field name="model">seisei.bank.statement.ocr.upload</field>
         <field name="arch" type="xml">
-            <form string="銀行対账単OCRアップロード">
+            <form string="銀行取引明細OCR / 银行对账单OCR / Bank Statement OCR">
                 <group>
                     <field name="journal_id"/>
-                    <field name="upload_mode" widget="radio"/>
-                </group>
-
-                <!-- Single file upload -->
-                <group invisible="upload_mode != 'single'">
-                    <field name="upload_file" filename="upload_filename"/>
-                    <field name="upload_filename" invisible="1"/>
+                    <field name="attachment_ids" widget="many2many_binary"/>
                     <p class="text-muted">
-                        PDF（複数ページ対応）または画像ファイル（JPG, PNG）をアップロードしてください。
+                        PDF（複数ページ対応）・画像（JPG, PNG）| 支持多页PDF及图片 | Multi-page PDF &amp; images supported
                     </p>
                 </group>
-
-                <!-- Batch file upload -->
-                <group invisible="upload_mode != 'batch'" string="ファイル一覧">
-                    <field name="file_ids" nolabel="1">
-                        <list editable="bottom">
-                            <field name="file_data" filename="filename"/>
-                            <field name="filename"/>
-                        </list>
-                    </field>
-                    <p class="text-muted">
-                        複数の対账単ファイルを追加してください。各ファイルごとに個別のOCRレコードが作成されます。
-                    </p>
-                </group>
-
                 <footer>
                     <button name="action_upload_and_ocr" type="object"
-                            string="OCR開始" class="btn-primary"/>
-                    <button string="キャンセル" class="btn-secondary" special="cancel"/>
+                            string="OCR開始 / 开始OCR / Start OCR"
+                            class="btn-primary"/>
+                    <button string="キャンセル / 取消 / Cancel"
+                            class="btn-secondary" special="cancel"/>
                 </footer>
             </form>
         </field>
@@ -44,7 +26,7 @@
 
     <!-- Upload Wizard Action -->
     <record id="action_bank_statement_ocr_upload" model="ir.actions.act_window">
-        <field name="name">銀行対账単OCRアップロード</field>
+        <field name="name">銀行取引明細OCR / 银行对账单OCR / Bank Statement OCR</field>
         <field name="res_model">seisei.bank.statement.ocr.upload</field>
         <field name="view_mode">form</field>
         <field name="view_id" ref="view_bank_statement_ocr_upload_form"/>

--- a/odoo_modules/seisei/seisei_bank_statement_ocr/wizard/bank_statement_ocr_upload.py
+++ b/odoo_modules/seisei/seisei_bank_statement_ocr/wizard/bank_statement_ocr_upload.py
@@ -1,60 +1,48 @@
-import base64
 import logging
 
-from odoo import models, fields, api
+from odoo import models, fields
 from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
-
-
-class BankStatementOcrUploadLine(models.TransientModel):
-    _name = 'seisei.bank.statement.ocr.upload.line'
-    _description = 'Bank Statement OCR Upload File Line'
-
-    wizard_id = fields.Many2one('seisei.bank.statement.ocr.upload', required=True, ondelete='cascade')
-    file_data = fields.Binary('ファイル', required=True)
-    filename = fields.Char('ファイル名')
 
 
 class BankStatementOcrUpload(models.TransientModel):
     _name = 'seisei.bank.statement.ocr.upload'
     _description = 'Bank Statement OCR Upload Wizard'
 
-    journal_id = fields.Many2one('account.journal', '銀行口座', required=True,
-                                  domain=[('type', '=', 'bank')])
-    upload_mode = fields.Selection([
-        ('single', '1件ずつ'),
-        ('batch', '一括アップロード'),
-    ], default='single', string='アップロード方式')
-
-    # Single upload
-    upload_file = fields.Binary('ファイル')
-    upload_filename = fields.Char('ファイル名')
-
-    # Batch upload
-    file_ids = fields.One2many('seisei.bank.statement.ocr.upload.line', 'wizard_id', 'ファイル一覧')
+    journal_id = fields.Many2one(
+        'account.journal',
+        '銀行口座 / 银行账户 / Bank Account',
+        required=True,
+        domain=[('type', '=', 'bank')],
+    )
+    attachment_ids = fields.Many2many(
+        'ir.attachment',
+        string='ファイル / 文件 / Files',
+    )
 
     def action_upload_and_ocr(self):
-        """Create OCR record(s), attach file(s), and trigger OCR."""
+        """Create one OCR record per uploaded file and trigger OCR."""
         self.ensure_one()
+        if not self.attachment_ids:
+            raise UserError(
+                'ファイルを選択してください。\n'
+                '请选择文件。\n'
+                'Please select files.'
+            )
+
         OcrRecord = self.env['seisei.bank.statement.ocr']
         created_ids = []
 
-        if self.upload_mode == 'single':
-            if not self.upload_file:
-                raise UserError('ファイルを選択してください。')
-            record = self._create_ocr_record(self.upload_file, self.upload_filename)
+        for attachment in self.attachment_ids:
+            record = OcrRecord.create({
+                'journal_id': self.journal_id.id,
+                'attachment_ids': [(6, 0, [attachment.id])],
+            })
             created_ids.append(record.id)
-        else:
-            if not self.file_ids:
-                raise UserError('ファイルを追加してください。')
-            for line in self.file_ids:
-                record = self._create_ocr_record(line.file_data, line.filename)
-                created_ids.append(record.id)
 
         # Trigger OCR on all created records
-        records = OcrRecord.browse(created_ids)
-        for record in records:
+        for record in OcrRecord.browse(created_ids):
             try:
                 record.action_process_ocr()
             except Exception as e:
@@ -62,7 +50,6 @@ class BankStatementOcrUpload(models.TransientModel):
                 record.ocr_error_message = str(e)
                 record.state = 'failed'
 
-        # Navigate to the created records
         if len(created_ids) == 1:
             return {
                 'type': 'ir.actions.act_window',
@@ -71,25 +58,10 @@ class BankStatementOcrUpload(models.TransientModel):
                 'view_mode': 'form',
                 'target': 'current',
             }
-        else:
-            return {
-                'type': 'ir.actions.act_window',
-                'res_model': 'seisei.bank.statement.ocr',
-                'view_mode': 'list,form',
-                'domain': [('id', 'in', created_ids)],
-                'target': 'current',
-            }
-
-    def _create_ocr_record(self, file_data, filename):
-        """Create an OCR record with the file as attachment."""
-        attachment = self.env['ir.attachment'].create({
-            'name': filename or 'bank_statement_scan',
-            'datas': file_data,
+        return {
+            'type': 'ir.actions.act_window',
             'res_model': 'seisei.bank.statement.ocr',
-            'type': 'binary',
-        })
-        record = self.env['seisei.bank.statement.ocr'].create({
-            'journal_id': self.journal_id.id,
-            'attachment_ids': [(6, 0, [attachment.id])],
-        })
-        return record
+            'view_mode': 'list,form',
+            'domain': [('id', 'in', created_ids)],
+            'target': 'current',
+        }


### PR DESCRIPTION
Fixes #88

## Summary
- **OCR Service**: Add `output_level='bank_statement'` with dedicated `PROMPT_BANK_STATEMENT` (方案B: server-side prompt management, no prompt in every request)
- **Upload Wizard**: Simplified — removed single/batch toggle, now just multi-file upload
- **Trilingual UI**: All labels, buttons, menus in JP / CN / EN

## Changes
| File | Change |
|------|--------|
| `services/ocr_service/main.py` | Add `PROMPT_BANK_STATEMENT`, accept `bank_statement` output_level |
| `wizard/bank_statement_ocr_upload.py` | Simplified: multi-file upload, removed upload line model |
| `views/*.xml` | Trilingual labels, simplified wizard form |
| `models/*.py` | Trilingual field labels and error messages |
| `security/ir.model.access.csv` | Removed unused upload_line access |
| `__manifest__.py` | Version bump to 18.0.1.1.0 |

## Test plan
- [ ] OCR service accepts `output_level=bank_statement` (no more 422)
- [ ] Upload wizard shows simple multi-file picker
- [ ] All labels display in JP/CN/EN
- [ ] Bank statement image OCR extracts transactions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)