### PR TITLE
fix(ocr): include response body in error messages

### DIFF
--- a/odoo_modules/seisei/odoo_ocr_final/models/llm_ocr.py
+++ b/odoo_modules/seisei/odoo_ocr_final/models/llm_ocr.py
@@ -331,7 +331,9 @@ def _call_ocr_service_raw(file_data: bytes, mimetype: str, tenant_id: str,
         )
 
         if response.status_code != 200:
-            return {'success': False, 'error': f'OCR service error: {response.status_code}'}
+            body = response.text[:500] if response.text else 'no body'
+            _logger.error(f'[OCR] HTTP {response.status_code}: {body}')
+            return {'success': False, 'error': f'OCR service error {response.status_code}: {body}'}
 
         result = response.json()
         if result.get('success'):
@@ -449,7 +451,9 @@ def _call_ocr_service(file_data: bytes, mimetype: str, tenant_id: str,
         )
 
         if response.status_code != 200:
-            return {'success': False, 'error': f'OCR service error: {response.status_code}'}
+            body = response.text[:500] if response.text else 'no body'
+            _logger.error(f'[OCR] HTTP {response.status_code}: {body}')
+            return {'success': False, 'error': f'OCR service error {response.status_code}: {body}'}
 
         result = response.json()
 


### PR DESCRIPTION
Fixes #88

## Summary
- Include OCR service response body in error messages (was only showing HTTP status code)
- This will reveal the actual Pydantic validation error when 422 occurs
- Helps debug why bank statement OCR returns 422 despite service being v1.5.0

## Test plan
- [ ] Deploy → retry OCR → error message now shows detailed reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)