### PR TITLE
fix(bank-ocr): show scan files as attachments in Chatter

### DIFF
--- a/odoo_modules/seisei/seisei_bank_statement_ocr/__manifest__.py
+++ b/odoo_modules/seisei/seisei_bank_statement_ocr/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': '銀行取引明細OCR / Bank Statement OCR',
-    'version': '18.0.1.5.0',
+    'version': '18.0.1.6.0',
     'category': 'Accounting',
     'summary': 'OCR import for scanned bank statements (PDF/Image)',
     'description': """

--- a/odoo_modules/seisei/seisei_bank_statement_ocr/models/bank_statement_ocr.py
+++ b/odoo_modules/seisei/seisei_bank_statement_ocr/models/bank_statement_ocr.py
@@ -150,12 +150,19 @@ class SeiseiBankStatementOcr(models.Model):
             self._apply_ocr_result(merged)
             self.state = 'review'
 
+            # Link scan attachments to this record so they appear in Chatter
+            self.attachment_ids.write({
+                'res_model': self._name,
+                'res_id': self.id,
+            })
+
             self.message_post(
                 body=_(
                     'OCR completed: %(pages)s pages, %(txns)s transactions extracted.',
                     pages=total_pages,
                     txns=len(merged['transactions']),
                 ),
+                attachment_ids=self.attachment_ids.ids,
             )
 
             OcrUsage = self.env['ocr.usage'].sudo()
@@ -297,6 +304,7 @@ class SeiseiBankStatementOcr(models.Model):
                 sname=statement.name,
                 count=len(self.line_ids),
             ),
+            attachment_ids=self.attachment_ids.ids,
         )
 
         return {


### PR DESCRIPTION
Closes #86 

## Summary
- Set `res_model`/`res_id` on scan attachments after OCR so they appear in Chatter's attachment section
- Pass `attachment_ids` to `message_post()` on OCR completion and import, so original scans are directly visible in the message thread for easy review
- Bump version to 18.0.1.6.0

## Test plan
- [ ] Upload scan → Run OCR → verify scan file appears as attachment in OCR completion message
- [ ] Import statement → verify scan file appears as attachment in import message
- [ ] Verify Chatter attachment section shows the scan file(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)