### PR TITLE
fix(deploy): healthcheck polling, rollback hardening, verified gate

### DIFF
--- a/.github/workflows/mark-verified.yml
+++ b/.github/workflows/mark-verified.yml
@@ -22,7 +22,8 @@ env:
 jobs:
   mark-verified:
     runs-on: ubuntu-latest
-    
+    environment: production
+
     steps:
       - name: Setup SSH key
         run: |


### PR DESCRIPTION
Closes #99 

## Summary
- **Healthcheck polling**: Replace fixed `sleep 15` with `wait_for_healthy()` in deploy.sh and rollback.sh — polls Docker healthcheck status up to 180s, proceeds immediately when healthy
- **First-deploy rollback guard**: `trigger_rollback()` now checks for existing current manifest before calling rollback.sh, avoiding confusing errors on first deploy
- **Friendly rollback errors**: rollback.sh gives actionable guidance instead of a terse `fail` when no deployment history exists
- **Smoke test retry**: Domain accessibility check retries 3x with 5s interval to handle transient network issues
- **Verified gate secrets**: `mark-verified.yml` now uses `environment: production` to access correct SSH secrets

## Root cause
Production first deploy (`sha-2ef08bf`) hit a triple failure:
1. `mark-verified.yml` used wrong SSH secrets (no `environment` set)
2. `sleep 15` was insufficient for Odoo with 19 databases (needs 2-5 min)
3. Auto-rollback crashed on first deploy with no history file

## Files changed
| File | Change |
|------|--------|
| `scripts/lib.sh` | New `wait_for_healthy()` shared function |
| `scripts/deploy.sh` | Healthcheck polling + rollback pre-check |
| `scripts/rollback.sh` | Healthcheck polling + friendly error messages |
| `scripts/smoke.sh` | Domain check 3x retry |
| `.github/workflows/mark-verified.yml` | `environment: production` |

## Test plan
- [ ] `bash -n` syntax check on all scripts (passes; pre-existing associative array warning unchanged)
- [ ] Merge → rsync to server via `Update Server Scripts` workflow
- [ ] Re-run `mark-verified.yml` for `sha-2ef08bf` (verify correct SSH target)
- [ ] Deploy to production, observe healthcheck polling in logs
- [ ] `curl -s -o /dev/null -w "%{http_code}" https://demo.nagashiro.top` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)