### PR TITLE
fix(deploy): inject DB_PASSWORD into odoo.conf at deploy time

### DIFF
--- a/infra/stacks/odoo18-prod/config/odoo.conf
+++ b/infra/stacks/odoo18-prod/config/odoo.conf
@@ -4,7 +4,8 @@ data_dir = /var/lib/odoo
 db_host = seisei-odoo18-prod-rds.c1emceusojse.ap-northeast-1.rds.amazonaws.com
 db_port = 5432
 db_user = odoo18
-db_password = Wind1982
+; db_password is injected by deploy.sh from .env DB_PASSWORD
+db_password = __DEPLOY_INJECT__
 admin_passwd = changeme
 workers = 4
 max_cron_threads = 2

--- a/infra/stacks/odoo18-staging/config/odoo.conf
+++ b/infra/stacks/odoo18-staging/config/odoo.conf
@@ -7,7 +7,8 @@ data_dir = /var/lib/odoo
 db_host = seisei-odoo18-staging-rds.c1emceusojse.ap-northeast-1.rds.amazonaws.com
 db_port = 5432
 db_user = odoo18
-db_password = Wind1982
+; db_password is injected by deploy.sh from .env DB_PASSWORD
+db_password = __DEPLOY_INJECT__
 db_sslmode = require
 db_maxconn = 64
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -525,6 +525,19 @@ if ! grep -q "^COMPOSE_PROJECT_NAME=" "$ENV_FILE"; then
     log_success "Added COMPOSE_PROJECT_NAME=$EXPECTED_PROJECT_NAME"
 fi
 
+# Inject DB_PASSWORD from .env into odoo.conf (if exists)
+# odoo.conf takes precedence over env vars for Odoo, so we must patch it
+ODOO_CONF="$RELEASE_DIR/config/odoo.conf"
+if [ -f "$ODOO_CONF" ]; then
+    DB_PASSWORD_VALUE=$(grep "^DB_PASSWORD=" "$ENV_FILE" | cut -d'=' -f2-)
+    if [ -n "$DB_PASSWORD_VALUE" ]; then
+        sed -i "s|^db_password = .*|db_password = $DB_PASSWORD_VALUE|" "$ODOO_CONF"
+        log_success "Injected DB_PASSWORD into odoo.conf"
+    else
+        log_warn "DB_PASSWORD not found in .env, odoo.conf db_password unchanged"
+    fi
+fi
+
 echo ""
 
 # =============================================================================


### PR DESCRIPTION
## Root cause of production 502

`odoo.conf` template had hardcoded staging DB password (`Wind1982`). `deploy.sh` copied it unchanged to the release directory. Odoo reads `odoo.conf` over env vars → `FATAL: password authentication failed`.

Fixes #97

### Changes
- `odoo.conf` (prod + staging): replace hardcoded `db_password` with `__DEPLOY_INJECT__` placeholder
- `deploy.sh` Step 5: inject `DB_PASSWORD` from `.env` into `odoo.conf` via `sed`

### Already applied
Production server `odoo.conf` was manually patched and container restarted — site is UP. This PR prevents recurrence on future deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)