### PR TITLE
feat(reports): remove Name header, add JA/ZH translations

### DIFF
--- a/odoo_modules/seisei/seisei_account_reports/__manifest__.py
+++ b/odoo_modules/seisei/seisei_account_reports/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': '財務報表 / Financial Reports',
-    'version': '18.0.1.1.0',
+    'version': '18.0.1.2.0',
     'category': 'Accounting',
     'summary': 'Interactive financial reports: P&L, Balance Sheet, General Ledger',
     'description': """

--- a/odoo_modules/seisei/seisei_account_reports/i18n/ja.po
+++ b/odoo_modules/seisei/seisei_account_reports/i18n/ja.po
@@ -1,0 +1,284 @@
+# Japanese translation for seisei_account_reports
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo 18.0\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+msgid "Reports"
+msgstr "レポート"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+msgid "Financial Statements"
+msgstr "財務諸表"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+#: data/profit_and_loss.xml
+msgid "Profit and Loss"
+msgstr "損益計算書"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+#: data/balance_sheet.xml
+msgid "Balance Sheet"
+msgstr "貸借対照表"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+msgid "Ledgers"
+msgstr "元帳"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+#: data/general_ledger.xml
+msgid "General Ledger"
+msgstr "総勘定元帳"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+#: data/balance_sheet.xml
+#: data/general_ledger.xml
+#: models/account_report_engine.py
+msgid "Balance"
+msgstr "残高"
+
+#. module: seisei_account_reports
+#: data/general_ledger.xml
+msgid "Date"
+msgstr "日付"
+
+#. module: seisei_account_reports
+#: data/general_ledger.xml
+msgid "Communication"
+msgstr "摘要"
+
+#. module: seisei_account_reports
+#: data/general_ledger.xml
+msgid "Partner"
+msgstr "取引先"
+
+#. module: seisei_account_reports
+#: data/general_ledger.xml
+msgid "Debit"
+msgstr "借方"
+
+#. module: seisei_account_reports
+#: data/general_ledger.xml
+msgid "Credit"
+msgstr "貸方"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Income"
+msgstr "収入"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Revenue"
+msgstr "売上高"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Other Income"
+msgstr "その他の収入"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Expenses"
+msgstr "費用"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Cost of Revenue"
+msgstr "売上原価"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Operating Expenses"
+msgstr "営業費用"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Depreciation"
+msgstr "減価償却費"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Net Profit"
+msgstr "純利益"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Assets"
+msgstr "資産"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Current Assets"
+msgstr "流動資産"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Bank and Cash Accounts"
+msgstr "現金及び預金"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Receivables"
+msgstr "売掛金"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Prepayments"
+msgstr "前払金"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Plus Non-current Assets"
+msgstr "固定資産合計"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Fixed Assets"
+msgstr "有形固定資産"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Non-current Assets"
+msgstr "その他の固定資産"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Liabilities"
+msgstr "負債"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Current Liabilities"
+msgstr "流動負債"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Payables"
+msgstr "買掛金"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Plus Non-current Liabilities"
+msgstr "固定負債合計"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Equity"
+msgstr "純資産"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Current Year Unallocated Earnings"
+msgstr "当期未処分利益"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Retained Earnings"
+msgstr "利益剰余金"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Liabilities + Equity"
+msgstr "負債・純資産合計"
+
+#. module: seisei_account_reports
+#: models/account_report_engine.py
+msgid "PDF"
+msgstr "PDF"
+
+#. module: seisei_account_reports
+#: models/account_report_engine.py
+msgid "XLSX"
+msgstr "XLSX"
+
+#. module: seisei_account_reports
+#: models/account_report_engine.py
+msgid "All Journals"
+msgstr "全仕訳帳"
+
+#. module: seisei_account_reports
+#: models/account_report_engine.py
+msgid "Undefined"
+msgstr "未定義"
+
+#. module: seisei_account_reports
+#: models/account_report_engine.py
+msgid "Load More..."
+msgstr "さらに読み込む..."
+
+#. module: seisei_account_reports
+#: models/account_general_ledger.py
+msgid "Initial Balance"
+msgstr "期首残高"
+
+#. module: seisei_account_reports
+#: models/account_report_actions.py
+msgid "Journal Items"
+msgstr "仕訳項目"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Draft"
+msgstr "下書き"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "No Comparison"
+msgstr "比較なし"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Monthly"
+msgstr "月次"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Quarterly"
+msgstr "四半期"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Semi-Annual"
+msgstr "半期"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Previous Period"
+msgstr "前期間"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Same Last Year"
+msgstr "前年同期"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Hide 0"
+msgstr "ゼロ非表示"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/account_report.js
+msgid "No data available for the selected period."
+msgstr "選択した期間のデータはありません。"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/line_name/line_name.js
+msgid "Fold"
+msgstr "折りたたむ"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/line_name/line_name.js
+msgid "Unfold"
+msgstr "展開する"

--- a/odoo_modules/seisei/seisei_account_reports/i18n/zh_CN.po
+++ b/odoo_modules/seisei/seisei_account_reports/i18n/zh_CN.po
@@ -1,0 +1,284 @@
+# Chinese (Simplified) translation for seisei_account_reports
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo 18.0\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+msgid "Reports"
+msgstr "报表"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+msgid "Financial Statements"
+msgstr "财务报表"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+#: data/profit_and_loss.xml
+msgid "Profit and Loss"
+msgstr "损益表"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+#: data/balance_sheet.xml
+msgid "Balance Sheet"
+msgstr "资产负债表"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+msgid "Ledgers"
+msgstr "账簿"
+
+#. module: seisei_account_reports
+#: data/menuitems.xml
+#: data/general_ledger.xml
+msgid "General Ledger"
+msgstr "总分类账"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+#: data/balance_sheet.xml
+#: data/general_ledger.xml
+#: models/account_report_engine.py
+msgid "Balance"
+msgstr "余额"
+
+#. module: seisei_account_reports
+#: data/general_ledger.xml
+msgid "Date"
+msgstr "日期"
+
+#. module: seisei_account_reports
+#: data/general_ledger.xml
+msgid "Communication"
+msgstr "摘要"
+
+#. module: seisei_account_reports
+#: data/general_ledger.xml
+msgid "Partner"
+msgstr "合作伙伴"
+
+#. module: seisei_account_reports
+#: data/general_ledger.xml
+msgid "Debit"
+msgstr "借方"
+
+#. module: seisei_account_reports
+#: data/general_ledger.xml
+msgid "Credit"
+msgstr "贷方"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Income"
+msgstr "收入"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Revenue"
+msgstr "营业收入"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Other Income"
+msgstr "其他收入"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Expenses"
+msgstr "费用"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Cost of Revenue"
+msgstr "营业成本"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Operating Expenses"
+msgstr "营业费用"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Depreciation"
+msgstr "折旧"
+
+#. module: seisei_account_reports
+#: data/profit_and_loss.xml
+msgid "Net Profit"
+msgstr "净利润"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Assets"
+msgstr "资产"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Current Assets"
+msgstr "流动资产"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Bank and Cash Accounts"
+msgstr "银行和现金账户"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Receivables"
+msgstr "应收款项"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Prepayments"
+msgstr "预付款项"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Plus Non-current Assets"
+msgstr "非流动资产合计"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Fixed Assets"
+msgstr "固定资产"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Non-current Assets"
+msgstr "其他非流动资产"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Liabilities"
+msgstr "负债"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Current Liabilities"
+msgstr "流动负债"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Payables"
+msgstr "应付款项"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Plus Non-current Liabilities"
+msgstr "非流动负债合计"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Equity"
+msgstr "所有者权益"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Current Year Unallocated Earnings"
+msgstr "本年未分配利润"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Retained Earnings"
+msgstr "留存收益"
+
+#. module: seisei_account_reports
+#: data/balance_sheet.xml
+msgid "Liabilities + Equity"
+msgstr "负债和所有者权益"
+
+#. module: seisei_account_reports
+#: models/account_report_engine.py
+msgid "PDF"
+msgstr "PDF"
+
+#. module: seisei_account_reports
+#: models/account_report_engine.py
+msgid "XLSX"
+msgstr "XLSX"
+
+#. module: seisei_account_reports
+#: models/account_report_engine.py
+msgid "All Journals"
+msgstr "全部日记账"
+
+#. module: seisei_account_reports
+#: models/account_report_engine.py
+msgid "Undefined"
+msgstr "未定义"
+
+#. module: seisei_account_reports
+#: models/account_report_engine.py
+msgid "Load More..."
+msgstr "加载更多..."
+
+#. module: seisei_account_reports
+#: models/account_general_ledger.py
+msgid "Initial Balance"
+msgstr "期初余额"
+
+#. module: seisei_account_reports
+#: models/account_report_actions.py
+msgid "Journal Items"
+msgstr "日记账分录"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Draft"
+msgstr "草稿"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "No Comparison"
+msgstr "不比较"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Monthly"
+msgstr "按月"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Quarterly"
+msgstr "按季度"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Semi-Annual"
+msgstr "半年度"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Previous Period"
+msgstr "前期"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Same Last Year"
+msgstr "同比去年"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/filters/filters.js
+msgid "Hide 0"
+msgstr "隐藏零值"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/account_report.js
+msgid "No data available for the selected period."
+msgstr "所选期间无可用数据。"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/line_name/line_name.js
+msgid "Fold"
+msgstr "折叠"
+
+#. module: seisei_account_reports
+#: static/src/components/account_report/line_name/line_name.js
+msgid "Unfold"
+msgstr "展开"

--- a/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/account_report.js
+++ b/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/account_report.js
@@ -3,6 +3,7 @@
 import { Component, useState, onWillStart, onMounted, onPatched, useRef, useSubEnv } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
 import { AccountReportController } from "./controller";
 import { AccountReportHeader } from "./header/header";
 import { AccountReportLine } from "./line/line";
@@ -40,6 +41,10 @@ export class AccountReport extends Component {
 
         onMounted(() => this._updateCpHeight());
         onPatched(() => this._updateCpHeight());
+    }
+
+    get emptyStateMessage() {
+        return _t("No data available for the selected period.");
     }
 
     _updateCpHeight() {

--- a/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/account_report.xml
+++ b/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/account_report.xml
@@ -35,7 +35,7 @@
                         <!-- Empty state -->
                         <tr t-if="!controller.lines.length">
                             <td colspan="99" class="text-center text-muted p-4">
-                                No data available for the selected period.
+                                <t t-esc="emptyStateMessage"/>
                             </td>
                         </tr>
                     </tbody>

--- a/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/filters/filters.js
+++ b/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/filters/filters.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { Component, useState } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 
 export class AccountReportFilters extends Component {
     static template = "seisei_account_reports.AccountReportFilters";
@@ -11,6 +12,29 @@ export class AccountReportFilters extends Component {
         this.state = useState({
             showJournals: false,
         });
+    }
+
+    get draftLabel() {
+        return _t("Draft");
+    }
+
+    get hideZeroLabel() {
+        return _t("Hide 0");
+    }
+
+    get allJournalsLabel() {
+        return _t("All Journals");
+    }
+
+    get comparisonOptions() {
+        return [
+            { value: "no_comparison", label: _t("No Comparison") },
+            { value: "monthly", label: _t("Monthly") },
+            { value: "quarterly", label: _t("Quarterly") },
+            { value: "semi_annual", label: _t("Semi-Annual") },
+            { value: "previous_period", label: _t("Previous Period") },
+            { value: "same_last_year", label: _t("Same Last Year") },
+        ];
     }
 
     get dateFrom() {
@@ -42,7 +66,7 @@ export class AccountReportFilters extends Component {
     }
 
     get journalGroupName() {
-        return this.controller.options?.name_journal_group || "All Journals";
+        return this.controller.options?.name_journal_group || this.allJournalsLabel;
     }
 
     get hideZeroLines() {

--- a/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/filters/filters.xml
+++ b/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/filters/filters.xml
@@ -23,7 +23,7 @@
                        id="filter_draft"
                        t-att-checked="isDraftIncluded"
                        t-on-change="onToggleDraft"/>
-                <label class="form-check-label small" for="filter_draft">Draft</label>
+                <label class="form-check-label small" for="filter_draft" t-esc="draftLabel"/>
             </div>
 
             <!-- Journal filter -->
@@ -54,12 +54,9 @@
                         style="width: auto; font-size: 0.85rem;"
                         t-att-value="comparisonFilter"
                         t-on-change="onComparisonChange">
-                    <option value="no_comparison">No Comparison</option>
-                    <option value="monthly">Monthly</option>
-                    <option value="quarterly">Quarterly</option>
-                    <option value="semi_annual">Semi-Annual</option>
-                    <option value="previous_period">Previous Period</option>
-                    <option value="same_last_year">Same Last Year</option>
+                    <t t-foreach="comparisonOptions" t-as="opt" t-key="opt.value">
+                        <option t-att-value="opt.value" t-esc="opt.label"/>
+                    </t>
                 </select>
                 <input t-if="isPreviousPeriod"
                        type="number"
@@ -77,7 +74,7 @@
                        id="filter_hide_zero"
                        t-att-checked="hideZeroLines"
                        t-on-change="onToggleHideZero"/>
-                <label class="form-check-label small" for="filter_hide_zero">Hide 0</label>
+                <label class="form-check-label small" for="filter_hide_zero" t-esc="hideZeroLabel"/>
             </div>
         </div>
     </t>

--- a/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/header/header.xml
+++ b/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/header/header.xml
@@ -15,7 +15,7 @@
         <!-- Single period: one header row -->
         <t t-else="">
             <tr>
-                <th class="o_account_report_name_header">Name</th>
+                <th/>
                 <t t-foreach="columns" t-as="column" t-key="column_index">
                     <th class="o_account_report_column_header" t-esc="column.name"/>
                 </t>

--- a/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/line_name/line_name.js
+++ b/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/line_name/line_name.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { Component, useState } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 
 export class AccountReportLineName extends Component {
     static template = "seisei_account_reports.AccountReportLineName";
@@ -23,6 +24,10 @@ export class AccountReportLineName extends Component {
 
     get isUnfolded() {
         return this.props.line.unfolded;
+    }
+
+    get foldUnfoldTitle() {
+        return this.isUnfolded ? _t("Fold") : _t("Unfold");
     }
 
     async onClickName(ev) {

--- a/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/line_name/line_name.xml
+++ b/odoo_modules/seisei/seisei_account_reports/static/src/components/account_report/line_name/line_name.xml
@@ -6,7 +6,7 @@
             <button t-if="showUnfoldButton"
                     class="o_account_report_unfold_button"
                     t-on-click="toggleFold"
-                    t-att-title="isUnfolded ? 'Fold' : 'Unfold'">
+                    t-att-title="foldUnfoldTitle">
                 <i t-att-class="isUnfolded ? 'fa fa-caret-down' : 'fa fa-caret-right'"/>
             </button>
             <span t-elif="!props.line.load_more" style="width: 20px; margin-right: 4px; display: inline-block;"/>

--- a/odoo_modules/seisei/seisei_account_reports/views/report_template.xml
+++ b/odoo_modules/seisei/seisei_account_reports/views/report_template.xml
@@ -15,7 +15,7 @@
                 <thead>
                     <t t-if="multi_period and period_headers">
                         <tr>
-                            <th style="width: 30%;">Name</th>
+                            <th style="width: 30%;"/>
                             <t t-foreach="period_headers" t-as="period" t-key="period_index">
                                 <th class="text-center"
                                     style="background-color: #f8f9fa; font-size: 0.8rem;"
@@ -26,7 +26,7 @@
                     </t>
                     <t t-else="">
                         <tr>
-                            <th style="width: 40%;">Name</th>
+                            <th style="width: 40%;"/>
                             <t t-foreach="column_headers" t-as="col" t-key="col_index">
                                 <th class="text-end" t-esc="col.get('name', '')"/>
                             </t>


### PR DESCRIPTION
Closes #106 

## Summary
- Remove hardcoded "Name" column header from single-period and PDF report views to match the multi-period layout (empty first column)
- Wrap all frontend UI strings with `_t()` for Odoo's translation framework
- Add `ja.po` and `zh_CN.po` with 50 entries each covering report names, filter labels, line items, and Python strings

## Test plan
- [ ] Verify "No Comparison" mode no longer shows "Name" header — matches Monthly/Quarterly layout
- [ ] Switch Odoo language to Japanese → confirm all menu items, report names, filter labels, and line names are translated
- [ ] Switch Odoo language to Chinese (Simplified) → verify same
- [ ] Export PDF in each language → confirm "Name" removed, other content translated
- [ ] Test General Ledger → verify column headers (Date, Communication, Partner, Debit, Credit, Balance) translated

🤖 Generated with [Claude Code](https://claude.com/claude-code)