### PR TITLE
fix(deploy): make stack a choice dropdown, fix capture step condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,9 +11,15 @@ on:
           - staging
           - production
       stack:
-        description: 'Stack to deploy (odoo18-staging, odoo18-prod, erp-seisei, etc.)'
+        description: 'Stack to deploy'
         required: true
-        type: string
+        type: choice
+        options:
+          - odoo18-prod
+          - odoo18-staging
+          - erp-seisei
+          - erp-seisei-staging
+          - ocr
       image_tag:
         description: 'Image tag (must be sha-xxxxxxx format, e.g., sha-abc123)'
         required: true
@@ -311,7 +317,7 @@ jobs:
           fi
 
       - name: Capture deployment results
-        if: always()
+        if: always() && steps.deploy.outcome != 'skipped'
         run: |
           STACK="${{ inputs.stack }}"
           ENV="${{ inputs.environment }}"


### PR DESCRIPTION
Closes #110 

## Summary
- **Stack input**: Changed from free-text `string` to `choice` dropdown with predefined options (`odoo18-prod`, `odoo18-staging`, `erp-seisei`, `erp-seisei-staging`, `ocr`). Prevents typos like `doo18-prod` that caused [run #21898955619](https://github.com/cameltravel666-crypto/seisei-odoo-addons/actions/runs/21898955619) to fail.
- **Capture deployment results**: Added condition `steps.deploy.outcome != 'skipped'` so it only runs when the deploy step actually executed. Previously, validation failures caused this `if: always()` step to attempt SSH without a key, producing misleading errors.

## Test plan
- [ ] Trigger "Deploy to Environment" workflow — verify stack is now a dropdown
- [ ] Trigger with invalid inputs — verify "Capture deployment results" step is skipped cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)