### PR TITLE
fix(deploy): increase health timeout for odoo18-prod

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -668,7 +668,11 @@ echo ""
 log_step "Step 8: Health Check and Smoke Tests"
 
 STACK_DIR=$(resolve_stack_dir "$STACK")
-if ! wait_for_healthy "$STACK_DIR" 300 "web"; then
+HEALTH_TIMEOUT=300
+if [ "$STACK" = "odoo18-prod" ]; then
+    HEALTH_TIMEOUT=600  # Odoo prod has 19 DBs, needs more startup time
+fi
+if ! wait_for_healthy "$STACK_DIR" "$HEALTH_TIMEOUT" "web"; then
     log_warn "Container not healthy, proceeding to smoke test for final verdict..."
 fi
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -58,8 +58,8 @@ fi
 log_info "Test 3: Checking domain accessibility..."
 DOMAIN=$(get_stack_domain "$STACK")
 if [ -n "$DOMAIN" ]; then
-    MAX_RETRIES=3
-    RETRY_INTERVAL=5
+    MAX_RETRIES=6
+    RETRY_INTERVAL=10
     HTTP_CODE="000"
     for attempt in $(seq 1 $MAX_RETRIES); do
         HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$DOMAIN" || echo "000")


### PR DESCRIPTION
Closes #112 

## Summary
- Production deploy failed because Odoo (19 DBs) needs >300s to start
- Health check timed out at 300s → smoke test got HTTP 502 → auto-rollback
- Increase `wait_for_healthy` to 600s for `odoo18-prod`
- Increase smoke test domain check retries from 3x5s to 6x10s

## Test plan
- [ ] Merge and sync scripts to server via "Update Server Scripts" workflow
- [ ] Re-trigger production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)