### PR TITLE
fix(deploy): use /var/tmp for deploy log, increase health timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -283,7 +283,7 @@ jobs:
           # Scripts are already executable (set during server preparation)
           # NO git pull - code in /opt is for scripts only
           # Runtime state is managed through /srv/releases/stacks
-          $DEPLOY_CMD 2>&1 | tee /tmp/deploy.log
+          $DEPLOY_CMD 2>&1 | tee /var/tmp/deploy.log
 
           # Check exit status
           EXIT_CODE=\${PIPESTATUS[0]}


### PR DESCRIPTION
Closes #114 
## Summary
- Use `/var/tmp/deploy.log` instead of `/tmp/deploy.log` to avoid permission denied when deployer user writes to a root-owned file
- Increase `wait_for_healthy` to 600s for `odoo18-prod` (19 DBs need more startup time)
- Increase smoke test domain retries from 3x5s to 6x10s

## Test plan
- [x] Production deploy succeeded with these fixes (run #21899768592)

🤖 Generated with [Claude Code](https://claude.com/claude-code)