### PR TITLE
feat(deploy): remove bind mount, add --modules upgrade

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,11 @@ on:
         description: '[Required with break_glass] Emergency reason'
         required: false
         type: string
+      modules_to_upgrade:
+        description: '[OPTIONAL] Comma-separated Odoo modules to upgrade after deploy'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -245,6 +250,11 @@ jobs:
             --digest-file /var/tmp/image-digests.json \
             --actor \"$ACTOR\" \
             --run-id \"$RUN_ID\""
+
+          MODULES="${{ inputs.modules_to_upgrade }}"
+          if [ -n "$MODULES" ]; then
+            DEPLOY_CMD="$DEPLOY_CMD --modules \"$MODULES\""
+          fi
 
           echo "[DEBUG] Full deploy command: $DEPLOY_CMD"
 

--- a/infra/stacks/odoo18-prod/docker-compose.yml
+++ b/infra/stacks/odoo18-prod/docker-compose.yml
@@ -58,7 +58,6 @@ services:
       - OCR_SERVICE_KEY=${OCR_SERVICE_KEY}
     volumes:
       - odoo18-prod-data:/var/lib/odoo
-      - /opt/seisei-odoo-addons/odoo_modules:/mnt/extra-addons:ro
       - ./config/odoo.conf:/etc/odoo/odoo.conf:ro
     networks:
       - seisei-odoo-network

--- a/infra/stacks/odoo18-staging/docker-compose.yml
+++ b/infra/stacks/odoo18-staging/docker-compose.yml
@@ -63,8 +63,6 @@ services:
       - odoo18-staging-data:/var/lib/odoo
       # Config file - environment-specific settings
       - ./config/odoo.conf:/etc/odoo/odoo.conf:ro
-      # Addons path parity with production
-      - /opt/seisei-odoo-addons/odoo_modules:/mnt/extra-addons:ro
     networks:
       - seisei-odoo-network
       - odoo18-staging-internal


### PR DESCRIPTION
Closes #116 

## Summary
- **Remove bind mount** from prod and staging `docker-compose.yml` — image's baked-in `/mnt/extra-addons/` is now the sole source of addons code
- **Add `--modules` flag** to `deploy.sh` (Step 8.5) — auto-discovers tenant databases via `psql`, stops web, runs `odoo -u` per DB, restarts; fails forward on error (no rollback since DB schema is partially changed)
- **Add `modules_to_upgrade` input** to `deploy.yml` workflow — wired through to SSH deploy command

## Key decisions
- Module upgrade runs **after** health check (Step 8), **before** manifest write (Step 9) — container must be healthy first
- Upgrade failure does **not** trigger rollback — DB schema is partially changed, rolling back the image would be worse
- `--modules` is optional — deploys without module changes skip Step 8.5 entirely

## Test plan
- [ ] Deploy to **staging** without `--modules` — verify image addons work (no bind mount)
- [ ] `docker exec odoo18-staging-web ls /mnt/extra-addons/seisei/` confirms files come from image
- [ ] Deploy to staging with `--modules seisei_account_reports` — verify upgrade log shows success
- [ ] Smoke tests pass on staging
- [ ] Deploy to **production** after staging verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)