### PR TITLE
fix: route erp.seisei.tokyo to BizNexus instead of Odoo

### DIFF
--- a/infra/stacks/edge-traefik/dynamic/routes-prod.yml
+++ b/infra/stacks/edge-traefik/dynamic/routes-prod.yml
@@ -29,7 +29,7 @@ http:
 
     # Odoo Production - ERP domains only
     odoo-prod:
-      rule: "Host(`odoo.seisei.tokyo`) || Host(`erp.seisei.tokyo`)"
+      rule: "Host(`odoo.seisei.tokyo`)"
       service: odoo-prod
       entryPoints:
         - websecure
@@ -64,7 +64,7 @@ http:
 
     # BizNexus Production
     biznexus-prod:
-      rule: "Host(`biznexus.seisei.tokyo`)"
+      rule: "Host(`erp.seisei.tokyo`) || Host(`biznexus.seisei.tokyo`)"
       service: biznexus-prod
       entryPoints:
         - websecure


### PR DESCRIPTION
Closes #120 

## Summary
- Removed `erp.seisei.tokyo` from `odoo-prod` Traefik router
- Added `erp.seisei.tokyo` to `biznexus-prod` Traefik router
- Fixes Google OAuth register redirect returning 404 (was hitting Odoo instead of BizNexus)

## Test plan
- [x] `curl https://erp.seisei.tokyo/register` → 200
- [x] `curl https://erp.seisei.tokyo/login` → 200
- [x] `curl https://demo.nagashiro.top/web/login` → 200 (Odoo unaffected)
- [x] Server files (`routes-prod.yml` + `routes.yml`) already updated and live
- [ ] Test full Google OAuth login/register flow in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)