### PR TITLE
feat(qr_ordering): batch QR label printing

### DIFF
--- a/odoo_modules/seisei/qr_ordering/__manifest__.py
+++ b/odoo_modules/seisei/qr_ordering/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': '扫码点餐 / QR Code Ordering',
-    'version': '18.0.1.0.3',
+    'version': '18.0.1.1.0',
     'category': 'Point of Sale',
     'summary': '客户扫描餐桌二维码自助点餐，订单同步到 POS',
     'description': '''

--- a/odoo_modules/seisei/qr_ordering/models/qr_table.py
+++ b/odoo_modules/seisei/qr_ordering/models/qr_table.py
@@ -291,3 +291,12 @@ class QrTable(models.Model):
             'url': f'/qr/print/{self.qr_token}',
             'target': 'new',
         }
+
+    def action_print_all_qr_codes(self):
+        """批量打印二维码"""
+        ids_str = ','.join(str(id) for id in self.ids)
+        return {
+            'type': 'ir.actions.act_url',
+            'url': f'/qr/print/batch?ids={ids_str}',
+            'target': 'new',
+        }

--- a/odoo_modules/seisei/qr_ordering/views/qr_ordering_templates.xml
+++ b/odoo_modules/seisei/qr_ordering/views/qr_ordering_templates.xml
@@ -493,6 +493,346 @@
         </t>
     </template>
 
+    <!-- Batch Print QR Codes Page — Label Mode -->
+    <template id="print_qr_batch_page" name="Batch Print QR Codes">
+        <t t-call="web.html_container">
+            <div class="qr-label-page">
+                <!-- Dynamic @page style — updated by JS -->
+                <style id="qr-page-style">
+                    @page { size: 62mm 62mm; margin: 3mm; }
+                </style>
+
+                <style>
+                    /* ===== Base ===== */
+                    .qr-label-page {
+                        font-family: Arial, 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+                        margin: 0; padding: 0;
+                    }
+
+                    /* ===== Toolbar (screen only) ===== */
+                    .qr-label-toolbar {
+                        position: sticky; top: 0; z-index: 100;
+                        background: #f8f9fa; border-bottom: 1px solid #ddd;
+                        padding: 12px 16px;
+                        display: flex; flex-wrap: wrap; align-items: center; gap: 12px;
+                    }
+                    .qr-label-toolbar label {
+                        font-size: 13px; font-weight: 600; margin: 0;
+                    }
+                    .qr-label-toolbar input[type="number"] {
+                        width: 60px; padding: 4px 6px; border: 1px solid #ccc;
+                        border-radius: 4px; text-align: center; font-size: 13px;
+                    }
+                    .qr-label-toolbar .unit { font-size: 12px; color: #666; margin-right: 4px; }
+                    .qr-label-presets { display: flex; gap: 4px; margin-left: 4px; }
+                    .qr-label-presets button {
+                        padding: 3px 8px; font-size: 11px; border: 1px solid #aaa;
+                        border-radius: 3px; background: #fff; cursor: pointer;
+                    }
+                    .qr-label-presets button:hover { background: #e9ecef; }
+                    .qr-label-presets button.active { background: #0d6efd; color: #fff; border-color: #0d6efd; }
+                    .qr-label-toolbar .toolbar-sep {
+                        width: 1px; height: 28px; background: #ccc; margin: 0 4px;
+                    }
+                    .qr-label-toolbar .btn { margin: 0; }
+                    .qr-label-count {
+                        font-size: 13px; color: #666; margin-left: auto;
+                    }
+
+                    /* ===== Screen preview: card list ===== */
+                    .qr-label-list {
+                        display: flex; flex-wrap: wrap; gap: 16px;
+                        justify-content: center; padding: 20px;
+                    }
+                    .qr-label-card {
+                        border: 1px dashed #999; border-radius: 4px;
+                        display: flex; flex-direction: column;
+                        align-items: center; justify-content: center;
+                        box-sizing: border-box; overflow: hidden;
+                        /* width/height set by JS via inline style */
+                    }
+                    .qr-label-title {
+                        font-weight: bold; text-align: center;
+                        line-height: 1.2; margin: 0;
+                    }
+                    .qr-label-img {
+                        display: block; margin: 0 auto;
+                    }
+                    .qr-label-name {
+                        font-weight: bold; text-align: center;
+                        border: 2px solid #000; padding: 2px 8px;
+                        display: inline-block; line-height: 1.2;
+                    }
+                    .qr-label-hint {
+                        text-align: center; color: #333;
+                        line-height: 1.2; margin: 0;
+                    }
+
+                    /* ===== Print: one label per page ===== */
+                    @media print {
+                        .qr-label-toolbar { display: none !important; }
+                        .qr-label-page { padding: 0; }
+                        .qr-label-list {
+                            display: block; padding: 0; gap: 0;
+                        }
+                        .qr-label-card {
+                            width: 100% !important; height: 100% !important;
+                            border: none; border-radius: 0;
+                            page-break-after: always;
+                            margin: 0; padding: 0;
+                        }
+                        .qr-label-card:last-child {
+                            page-break-after: auto;
+                        }
+                    }
+                </style>
+
+                <!-- Toolbar -->
+                <div class="qr-label-toolbar no-print">
+                    <label>宽度:</label>
+                    <input id="label-w" type="number" value="62" min="20" max="200" onchange="updatePageSize()" oninput="updatePageSize()"/>
+                    <span class="unit">mm</span>
+
+                    <label>高度:</label>
+                    <input id="label-h" type="number" value="62" min="20" max="200" onchange="updatePageSize()" oninput="updatePageSize()"/>
+                    <span class="unit">mm</span>
+
+                    <label>边距:</label>
+                    <input id="label-m" type="number" value="3" min="0" max="20" onchange="updatePageSize()" oninput="updatePageSize()"/>
+                    <span class="unit">mm</span>
+
+                    <div class="qr-label-presets">
+                        <button type="button" onclick="applyPreset(62,62,3)">62×62</button>
+                        <button type="button" onclick="applyPreset(62,100,3)">62×100</button>
+                        <button type="button" onclick="applyPreset(62,29,2)">62×29</button>
+                        <button type="button" onclick="applyPreset(50,50,3)">50×50</button>
+                    </div>
+
+                    <div class="toolbar-sep"/>
+
+                    <button type="button" onclick="window.print()" class="btn btn-primary btn-sm">
+                        <i class="fa fa-print"/> 打印
+                    </button>
+                    <button type="button" onclick="exportImages()" class="btn btn-success btn-sm">
+                        <i class="fa fa-download"/> 导出图片
+                    </button>
+                    <button type="button" onclick="window.close()" class="btn btn-secondary btn-sm">
+                        <i class="fa fa-times"/> 关闭
+                    </button>
+
+                    <span class="qr-label-count">
+                        共 <t t-esc="len(tables_data)"/> 个桌台
+                    </span>
+                </div>
+
+                <!-- Label Cards -->
+                <div class="qr-label-list" id="qr-label-list">
+                    <t t-foreach="tables_data" t-as="item">
+                        <div class="qr-label-card"
+                             t-att-data-name="item['table'].name"
+                             t-att-data-barcode="item['barcode_url']">
+                            <div class="qr-label-title">扫码点餐</div>
+                            <img class="qr-label-img" t-att-src="item['barcode_url']" alt="QR Code" crossorigin="anonymous"/>
+                            <div class="qr-label-name" t-esc="item['table'].name"/>
+                            <div class="qr-label-hint">请扫描二维码点餐</div>
+                        </div>
+                    </t>
+                </div>
+
+                <script>
+                    /* ===== Size control ===== */
+                    function getVals() {
+                        return {
+                            w: parseInt(document.getElementById('label-w').value) || 62,
+                            h: parseInt(document.getElementById('label-h').value) || 62,
+                            m: parseInt(document.getElementById('label-m').value) || 3
+                        };
+                    }
+
+                    function updatePageSize() {
+                        var v = getVals();
+                        // Update @page
+                        document.getElementById('qr-page-style').textContent =
+                            '@page { size: ' + v.w + 'mm ' + v.h + 'mm; margin: ' + v.m + 'mm; }';
+                        updateCardPreview(v.w, v.h, v.m);
+                        // Persist
+                        try { localStorage.setItem('qr_label_size', JSON.stringify(v)); } catch(e) {}
+                        // Highlight matching preset
+                        highlightPreset(v.w, v.h, v.m);
+                    }
+
+                    function updateCardPreview(w, h, m) {
+                        var contentW = w - 2 * m;
+                        var contentH = h - 2 * m;
+                        var scale = 3.78;  // 1mm ≈ 3.78px at 96dpi
+                        var cardW = contentW * scale;
+                        var cardH = contentH * scale;
+                        var qrSize = Math.min(contentW, contentH) * 0.60 * scale;
+                        var titleSize = Math.max(10, Math.min(contentW, contentH) * 0.08);
+                        var nameSize = Math.max(12, Math.min(contentW, contentH) * 0.14);
+                        var hintSize = Math.max(8, Math.min(contentW, contentH) * 0.06);
+                        var nameBorder = Math.max(1, Math.min(contentW, contentH) * 0.015);
+                        var gap = Math.max(2, contentH * 0.02) + 'px';
+
+                        var cards = document.querySelectorAll('.qr-label-card');
+                        for (var i = 0; i &lt; cards.length; i++) {
+                            var c = cards[i];
+                            c.style.width = cardW + 'px';
+                            c.style.height = cardH + 'px';
+                            c.style.padding = (m * scale * 0.3) + 'px';
+                            c.style.gap = gap;
+
+                            var img = c.querySelector('.qr-label-img');
+                            if (img) { img.style.width = qrSize + 'px'; img.style.height = qrSize + 'px'; }
+
+                            var title = c.querySelector('.qr-label-title');
+                            if (title) title.style.fontSize = titleSize + 'px';
+
+                            var name = c.querySelector('.qr-label-name');
+                            if (name) {
+                                name.style.fontSize = nameSize + 'px';
+                                name.style.borderWidth = nameBorder + 'px';
+                                name.style.padding = '1px ' + Math.max(4, nameSize * 0.3) + 'px';
+                            }
+
+                            var hint = c.querySelector('.qr-label-hint');
+                            if (hint) hint.style.fontSize = hintSize + 'px';
+                        }
+                    }
+
+                    function applyPreset(w, h, m) {
+                        document.getElementById('label-w').value = w;
+                        document.getElementById('label-h').value = h;
+                        document.getElementById('label-m').value = m;
+                        updatePageSize();
+                    }
+
+                    function highlightPreset(w, h, m) {
+                        var presets = [[62,62,3],[62,100,3],[62,29,2],[50,50,3]];
+                        var btns = document.querySelectorAll('.qr-label-presets button');
+                        for (var i = 0; i &lt; btns.length; i++) {
+                            var p = presets[i];
+                            btns[i].classList.toggle('active', p &amp;&amp; p[0]===w &amp;&amp; p[1]===h &amp;&amp; p[2]===m);
+                        }
+                    }
+
+                    /* ===== Restore from localStorage ===== */
+                    function restoreSettings() {
+                        try {
+                            var saved = JSON.parse(localStorage.getItem('qr_label_size'));
+                            if (saved) {
+                                document.getElementById('label-w').value = saved.w || 62;
+                                document.getElementById('label-h').value = saved.h || 62;
+                                document.getElementById('label-m').value = saved.m || 3;
+                            }
+                        } catch(e) {}
+                        updatePageSize();
+                    }
+
+                    /* ===== Export PNG ===== */
+                    async function exportImages() {
+                        var cards = document.querySelectorAll('.qr-label-card');
+                        var v = getVals();
+                        var dpi = 300;
+                        var mmToPx = dpi / 25.4;
+                        var canvasW = Math.round((v.w - 2 * v.m) * mmToPx);
+                        var canvasH = Math.round((v.h - 2 * v.m) * mmToPx);
+                        var qrSize = Math.round(Math.min(canvasW, canvasH) * 0.60);
+                        var titleFontSize = Math.round(Math.min(canvasW, canvasH) * 0.08);
+                        var nameFontSize = Math.round(Math.min(canvasW, canvasH) * 0.14);
+                        var hintFontSize = Math.round(Math.min(canvasW, canvasH) * 0.06);
+
+                        for (var i = 0; i &lt; cards.length; i++) {
+                            var card = cards[i];
+                            var name = card.getAttribute('data-name') || ('table_' + i);
+                            var imgSrc = card.getAttribute('data-barcode');
+
+                            var canvas = document.createElement('canvas');
+                            canvas.width = canvasW;
+                            canvas.height = canvasH;
+                            var ctx = canvas.getContext('2d');
+
+                            // White background
+                            ctx.fillStyle = '#ffffff';
+                            ctx.fillRect(0, 0, canvasW, canvasH);
+                            ctx.fillStyle = '#000000';
+                            ctx.textAlign = 'center';
+                            ctx.textBaseline = 'middle';
+
+                            // Layout vertical positions
+                            var titleY = canvasH * 0.08;
+                            var qrY = (canvasH - qrSize) * 0.42;
+                            var nameY = qrY + qrSize + canvasH * 0.06;
+                            var hintY = canvasH * 0.93;
+                            var cx = canvasW / 2;
+
+                            // Title
+                            ctx.font = 'bold ' + titleFontSize + 'px Arial, sans-serif';
+                            ctx.fillText('扫码点餐', cx, titleY);
+
+                            // QR image
+                            try {
+                                var qrImg = await loadImage(imgSrc);
+                                ctx.drawImage(qrImg, cx - qrSize/2, qrY, qrSize, qrSize);
+                            } catch(e) {
+                                ctx.fillStyle = '#ccc';
+                                ctx.fillRect(cx - qrSize/2, qrY, qrSize, qrSize);
+                                ctx.fillStyle = '#000';
+                            }
+
+                            // Name with border
+                            ctx.font = 'bold ' + nameFontSize + 'px Arial, sans-serif';
+                            var nameMetrics = ctx.measureText(name);
+                            var namePadX = nameFontSize * 0.5;
+                            var namePadY = nameFontSize * 0.2;
+                            var nameBoxW = nameMetrics.width + namePadX * 2;
+                            var nameBoxH = nameFontSize + namePadY * 2;
+                            ctx.strokeStyle = '#000';
+                            ctx.lineWidth = Math.max(2, nameFontSize * 0.08);
+                            ctx.strokeRect(cx - nameBoxW/2, nameY - nameBoxH/2, nameBoxW, nameBoxH);
+                            ctx.fillText(name, cx, nameY);
+
+                            // Hint
+                            ctx.font = hintFontSize + 'px Arial, sans-serif';
+                            ctx.fillStyle = '#333';
+                            ctx.fillText('请扫描二维码点餐', cx, hintY);
+
+                            // Download
+                            await downloadCanvas(canvas, 'QR_' + name + '.png');
+                        }
+                    }
+
+                    function loadImage(src) {
+                        return new Promise(function(resolve, reject) {
+                            var img = new Image();
+                            img.crossOrigin = 'anonymous';
+                            img.onload = function() { resolve(img); };
+                            img.onerror = reject;
+                            img.src = src;
+                        });
+                    }
+
+                    function downloadCanvas(canvas, filename) {
+                        return new Promise(function(resolve) {
+                            canvas.toBlob(function(blob) {
+                                var a = document.createElement('a');
+                                a.href = URL.createObjectURL(blob);
+                                a.download = filename;
+                                document.body.appendChild(a);
+                                a.click();
+                                document.body.removeChild(a);
+                                setTimeout(function() { URL.revokeObjectURL(a.href); resolve(); }, 100);
+                            }, 'image/png');
+                        });
+                    }
+
+                    /* ===== Init ===== */
+                    document.addEventListener('DOMContentLoaded', restoreSettings);
+                </script>
+            </div>
+        </t>
+    </template>
+
     <!--
         V2 Ordering Page Template - Mobile-first Extreme Experience
         Features: Pinned video carousel, Reco rail with PiP, Sticky chips, 2-col grid with stepper

--- a/odoo_modules/seisei/qr_ordering/views/qr_table_views.xml
+++ b/odoo_modules/seisei/qr_ordering/views/qr_table_views.xml
@@ -7,6 +7,9 @@
         <field name="model">qr.table</field>
         <field name="arch" type="xml">
             <list string="QR Tables">
+                <header>
+                    <button name="action_print_all_qr_codes" string="批量打印 QR" type="object" class="btn-secondary"/>
+                </header>
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="short_code"/>


### PR DESCRIPTION
Closes #136 
## Summary
- Add「批量打印 QR」button in table list view
- Custom label size (width/height/margin mm) with presets (62×62, 62×100, 62×29, 50×50)
- One label per page print via dynamic @page CSS
- PNG export at 300 DPI for P-touch Editor
- Settings saved to localStorage

## Test plan
- [x] Tested on staging — QR ordering functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)